### PR TITLE
feat: japanese locale ja_jp implementation

### DIFF
--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -10,6 +10,8 @@ import { svSE } from './locales/sv-SE'
 import { datePickerSvSE } from './locales/sv-SE/date-picker'
 import { zhCN } from './locales/zh-CN'
 import { datePickerZhCN } from './locales/zh-CN/date-picker'
+import { jaJP } from './locales/ja-JP'
+import { datePickerJaJP } from './locales/ja-JP/date-picker'
 
 import { translate } from './translator/translate'
 
@@ -20,6 +22,7 @@ const translations = {
   enGB,
   svSE,
   zhCN,
+  jaJP,
 }
 
 const datePickerTranslations = {
@@ -29,6 +32,7 @@ const datePickerTranslations = {
   enGB: datePickerEnGB,
   svSE: datePickerSvSE,
   zhCN: datePickerZhCN,
+  jaJP: datePickerJaJP,
 }
 
 export {
@@ -41,4 +45,5 @@ export {
   enGB,
   svSE,
   zhCN,
+  jaJP,
 }

--- a/packages/translations/src/locales/ja-JP/calendar.ts
+++ b/packages/translations/src/locales/ja-JP/calendar.ts
@@ -1,0 +1,15 @@
+import { CalendarTranslations } from '../../types/calendar.translations'
+
+export const calendarJaJP: CalendarTranslations = {
+  Today: '今日',
+  Month: '月',
+  Week: '週',
+  Day: '日',
+  events: 'イベント',
+  event: 'イベント',
+  'No events': 'イベントなし',
+  'Next period': '次の期間',
+  'Previous period': '前の期間',
+  to: 'から', // as in 2/1/2020 to 2/2/2020
+  'Full day- and multiple day events': '終日および複数日イベント',
+}

--- a/packages/translations/src/locales/ja-JP/date-picker.ts
+++ b/packages/translations/src/locales/ja-JP/date-picker.ts
@@ -1,0 +1,10 @@
+import { DatePickerTranslations } from '../../types/date-picker.translations'
+
+export const datePickerJaJP: DatePickerTranslations = {
+  Date: '日付',
+  'MM/DD/YYYY': '年/月/日',
+  'Next month': '次の月',
+  'Previous month': '前の月',
+  'Choose Date': '日付を選択',
+  'Select View': 'ビューを選択',
+}

--- a/packages/translations/src/locales/ja-JP/index.ts
+++ b/packages/translations/src/locales/ja-JP/index.ts
@@ -1,0 +1,8 @@
+import { datePickerJaJP } from './date-picker'
+import { Language } from '../../types/language.translations'
+import { calendarJaJP } from './calendar'
+
+export const jaJP: Language = {
+  ...datePickerJaJP,
+  ...calendarJaJP,
+}


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [X] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [X] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

## This PR solves the following problem**. 

Resolve #161 

## How to test this PR**. 
1. Open `main.tsx` files located in the `./development` directory.
2. Change the `locale` configuration in both `createCalendar` and `createDatePicker` to:
   ```javascript
   locale: 'ja-JP',
   ```
3. Run the development server with the command:
   ```
   npm run dev
   ``` 