### PR TITLE
fix: fix DST recurrence calculation

### DIFF
--- a/packages/event-recurrence/src/__test__/create-recurrence.spec.ts
+++ b/packages/event-recurrence/src/__test__/create-recurrence.spec.ts
@@ -34,5 +34,32 @@ describe('Creating recurrences for events', () => {
       expect(events[3].start).toEqual('2024-02-25 16:00')
       expect(events[3].end).toEqual('2024-02-25 17:00')
     })
+
+    it('should create recurrence for all Saturdays in March 2024', () => {
+      const eventWithRRule: CalendarEventExternal = {
+        id: '1',
+        title: 'Weekly event',
+        start: '2024-03-02 16:00',
+        end: '2024-03-02 17:00',
+        rrule: 'FREQ=WEEKLY;BYDAY=SA;UNTIL=20240331T235959;',
+      }
+      const $app = __createAppWithViews__({
+        events: [eventWithRRule],
+      })
+      createEventRecurrencePlugin().init!($app)
+
+      const events = $app.calendarEvents.list.value
+      expect(events).toHaveLength(5)
+      expect(events[0].start).toEqual('2024-03-02 16:00')
+      expect(events[0].end).toEqual('2024-03-02 17:00')
+      expect(events[1].start).toEqual('2024-03-09 16:00')
+      expect(events[1].end).toEqual('2024-03-09 17:00')
+      expect(events[2].start).toEqual('2024-03-16 16:00')
+      expect(events[2].end).toEqual('2024-03-16 17:00')
+      expect(events[3].start).toEqual('2024-03-23 16:00')
+      expect(events[3].end).toEqual('2024-03-23 17:00')
+      expect(events[4].start).toEqual('2024-03-30 16:00')
+      expect(events[4].end).toEqual('2024-03-30 17:00')
+    })
   })
 })

--- a/packages/recurrence/src/rrule/utils/stateless/__test__/get-week-for-date.spec.ts
+++ b/packages/recurrence/src/rrule/utils/stateless/__test__/get-week-for-date.spec.ts
@@ -33,4 +33,44 @@ describe('getWeekForDate', () => {
       '2024-02-03',
     ])
   })
+
+  it('should return the week dates for 2024-03-30', () => {
+    const result = getWeekForDate('2024-03-30')
+    console.log(result)
+    expect(result).toEqual([
+      '2024-03-24',
+      '2024-03-25',
+      '2024-03-26',
+      '2024-03-27',
+      '2024-03-28',
+      '2024-03-29',
+      '2024-03-30',
+    ])
+  })
+
+  it('should return the week dates for 2024-02-04', () => {
+    const result = getWeekForDate('2024-02-04')
+    expect(result).toEqual([
+      '2024-02-04',
+      '2024-02-05',
+      '2024-02-06',
+      '2024-02-07',
+      '2024-02-08',
+      '2024-02-09',
+      '2024-02-10',
+    ])
+  })
+
+  it('should return the week dates for 2024-04-06', () => {
+    const result = getWeekForDate('2024-04-01')
+    expect(result).toEqual([
+      '2024-03-31',
+      '2024-04-01',
+      '2024-04-02',
+      '2024-04-03',
+      '2024-04-04',
+      '2024-04-05',
+      '2024-04-06',
+    ])
+  })
 })

--- a/packages/recurrence/src/rrule/utils/stateless/__test__/get-week-for-date.spec.ts
+++ b/packages/recurrence/src/rrule/utils/stateless/__test__/get-week-for-date.spec.ts
@@ -36,7 +36,6 @@ describe('getWeekForDate', () => {
 
   it('should return the week dates for 2024-03-30', () => {
     const result = getWeekForDate('2024-03-30')
-    console.log(result)
     expect(result).toEqual([
       '2024-03-24',
       '2024-03-25',

--- a/packages/recurrence/src/rrule/utils/stateless/get-week-for-date.ts
+++ b/packages/recurrence/src/rrule/utils/stateless/get-week-for-date.ts
@@ -4,12 +4,13 @@ import { toDateString } from '@schedule-x/shared/src/utils/stateless/time/format
 export const getWeekForDate = (date: string) => {
   const dateJS = toJSDate(date)
   const dayOfWeek = dateJS.getDay()
-  const startOfWeek = new Date(
-    dateJS.getTime() - dayOfWeek * 24 * 60 * 60 * 1000
-  )
+  const startOfWeek = new Date(dateJS)
+  startOfWeek.setDate(dateJS.getDate() - dayOfWeek)
+  startOfWeek.setHours(0, 0, 0, 0)
 
   return Array.from({ length: 7 }).map((_, index) => {
-    const day = new Date(startOfWeek.getTime() + index * 24 * 60 * 60 * 1000)
+    const day = new Date(startOfWeek)
+    day.setDate(startOfWeek.getDate() + index)
     return toDateString(day)
   })
 }


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [ ] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

## This PR solves the following problem**. 

There's an issue where due to DST, the start of the week is miscalculated due to using milliseconds-based calculation, I changed it so that it uses the `setDate` API which accounts for DST.

## How to test this PR**. 

I added tests to cover the edge cases I encountered.
