### PR TITLE
Upper case ru lang

### DIFF
--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -27,15 +27,14 @@ import { createCurrentTimePlugin } from '../../packages/current-time/src/current
 const calendarElement = document.getElementById('calendar') as HTMLElement
 
 const scrollControllerPlugin = createScrollControllerPlugin({
-  initialScroll: '07:50'
+  initialScroll: '07:50',
 })
 
 class CalendarsUpdaterPlugin {
   name: string = 'calendars-updater'
   $app!: CalendarAppSingleton
 
-  destroy(): void {
-  }
+  destroy(): void {}
 
   init($app: CalendarAppSingleton): void {
     this.$app = $app
@@ -62,7 +61,6 @@ class CalendarsUpdaterPlugin {
 }
 const calendarsUpdaterPlugin = new CalendarsUpdaterPlugin()
 
-
 const calendarControlsPlugin = createCalendarControlsPlugin()
 const calendar = createCalendar({
   // weekOptions: {
@@ -72,7 +70,7 @@ const calendar = createCalendar({
   // locale: 'ja-JP',
   // locale: 'en-US',
   // locale: 'zh-CN',
-  // locale: 'fr-FR',
+  locale: 'ky-KG',
   views: [viewMonthGrid, viewWeek, viewDay, viewMonthAgenda],
   // defaultView: viewWeek.name,
   // minDate: '2024-01-01',
@@ -106,7 +104,7 @@ const calendar = createCalendar({
 
     onClickDateTime(dateTime) {
       console.log('onClickDateTime', dateTime)
-    }
+    },
   },
   calendars: {
     personal: {
@@ -223,8 +221,8 @@ const calendar = createCalendar({
       title: 'Yearly event',
       start: '2024-02-08 16:00',
       end: '2024-02-08 17:55',
-      id: 874367853
-    }
+      id: 874367853,
+    },
   ],
 })
 calendar.render(calendarElement)
@@ -249,28 +247,39 @@ addEventButton.addEventListener('click', () => {
 
 const scrollButton = document.getElementById('scroll') as HTMLButtonElement
 scrollButton.addEventListener('click', () => {
-  scrollControllerPlugin.scrollTo((document.getElementById('scroll-to') as HTMLInputElement).value)
+  scrollControllerPlugin.scrollTo(
+    (document.getElementById('scroll-to') as HTMLInputElement).value
+  )
 })
 
-const logAllEventsButton = document.getElementById('log-all-events') as HTMLButtonElement
+const logAllEventsButton = document.getElementById(
+  'log-all-events'
+) as HTMLButtonElement
 logAllEventsButton.addEventListener('click', () => {
   console.log(calendar.events.getAll())
 })
 
-const setDateButton = document.getElementById('set-date-button') as HTMLButtonElement
+const setDateButton = document.getElementById(
+  'set-date-button'
+) as HTMLButtonElement
 setDateButton.addEventListener('click', () => {
-  const newDate = (document.getElementById('set-date') as HTMLInputElement).value
+  const newDate = (document.getElementById('set-date') as HTMLInputElement)
+    .value
   calendarControlsPlugin.setDate(newDate)
 })
 
-const setViewButton = document.getElementById('set-view-button') as HTMLButtonElement
+const setViewButton = document.getElementById(
+  'set-view-button'
+) as HTMLButtonElement
 setViewButton.addEventListener('click', () => {
-  const newView = (document.getElementById('set-view') as HTMLInputElement).value
+  const newView = (document.getElementById('set-view') as HTMLInputElement)
+    .value
   calendarControlsPlugin.setView(newView)
 })
 
-const updateCalendarsButton = document.getElementById('update-calendars') as HTMLButtonElement
+const updateCalendarsButton = document.getElementById(
+  'update-calendars'
+) as HTMLButtonElement
 updateCalendarsButton.addEventListener('click', () => {
   calendarsUpdaterPlugin.updateCalendars()
 })
-

--- a/packages/calendar/src/utils/stateless/range-heading.ts
+++ b/packages/calendar/src/utils/stateless/range-heading.ts
@@ -2,11 +2,51 @@ import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/cal
 import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
 
 const getLocaleStringMonthArgs = ($app: CalendarAppSingleton) => {
+  if ($app.config.locale === 'ky-KG') {
+    // ky-KG has no support in chrome since has to opt for ru-RU lang as options as it's 99% readable in KG region
+    return ['ru-RU', { month: 'long' }] as const
+  }
   return [$app.config.locale, { month: 'long' }] as const
 }
 
 const getLocaleStringYearArgs = ($app: CalendarAppSingleton) => {
+  if ($app.config.locale === 'ky-KG') {
+    // ky-KG has no support in chrome since has to opt for ru-RU lang as options as it's 99% readable in KG region
+    return ['ru-RU', { year: 'numeric' }] as const
+  }
   return [$app.config.locale, { year: 'numeric' }] as const
+}
+
+// convertTo_RuRU_If_KyKG_or_RuRU needed since the browsers treat ru locale with lowerCase
+
+const convertToUpperCase_If_KyKG_or_RuRU_Locale = (
+  $app: CalendarAppSingleton,
+  rangeStart: string,
+  rangeEnd: string
+): string => {
+  let startDateMonth = toJSDate(rangeStart).toLocaleString(
+    ...getLocaleStringMonthArgs($app)
+  )
+
+  const startDateYear = toJSDate(rangeStart).toLocaleString(
+    ...getLocaleStringYearArgs($app)
+  )
+  let endDateMonth = toJSDate(rangeEnd).toLocaleString(
+    ...getLocaleStringMonthArgs($app)
+  )
+
+  const endDateYear = toJSDate(rangeEnd).toLocaleString(
+    ...getLocaleStringYearArgs($app)
+  )
+  startDateMonth = startDateMonth[0].toUpperCase() + startDateMonth.slice(1)
+  endDateMonth = endDateMonth[0].toUpperCase() + endDateMonth.slice(1)
+  if (startDateMonth === endDateMonth && startDateYear === endDateYear) {
+    return `${startDateMonth} ${startDateYear}`
+  } else if (startDateMonth !== endDateMonth && startDateYear === endDateYear) {
+    return `${startDateMonth} – ${endDateMonth} ${startDateYear}`
+  }
+
+  return `${startDateMonth} ${startDateYear} – ${endDateMonth} ${endDateYear}`
 }
 
 export const getMonthAndYearForDateRange = (
@@ -14,15 +54,22 @@ export const getMonthAndYearForDateRange = (
   rangeStart: string,
   rangeEnd: string
 ): string => {
+  if ($app.config.locale === 'ru-RU' || $app.config.locale === 'ky-KG') {
+    // convertTo_RuRU_If_KyKG_or_RuRU needed since the browsers treat ru locale with lowerCase
+    return convertToUpperCase_If_KyKG_or_RuRU_Locale($app, rangeStart, rangeEnd)
+  }
   const startDateMonth = toJSDate(rangeStart).toLocaleString(
     ...getLocaleStringMonthArgs($app)
   )
+
   const startDateYear = toJSDate(rangeStart).toLocaleString(
     ...getLocaleStringYearArgs($app)
   )
+
   const endDateMonth = toJSDate(rangeEnd).toLocaleString(
     ...getLocaleStringMonthArgs($app)
   )
+
   const endDateYear = toJSDate(rangeEnd).toLocaleString(
     ...getLocaleStringYearArgs($app)
   )

--- a/packages/shared/src/utils/stateless/time/date-time-localization/date-time-localization.ts
+++ b/packages/shared/src/utils/stateless/time/date-time-localization/date-time-localization.ts
@@ -1,8 +1,20 @@
 export const toLocalizedMonth = (date: Date, locale: string): string => {
+  if (locale === 'ky-KG') {
+    // ky-KG has no support in chrome since has to opt for ru-RU lang as options as it's 99% readable in KG region
+    return date.toLocaleString('ru-RU', { month: 'long' })
+  }
   return date.toLocaleString(locale, { month: 'long' })
 }
 
 export const toLocalizedDate = (date: Date, locale: string): string => {
+  if (locale === 'ky-KG') {
+    // ky-KG has no support in chrome since has to opt for ru-RU lang as options as it's 99% readable in KG region
+    return date.toLocaleString('ru-RU', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
   return date.toLocaleString(locale, {
     month: 'long',
     day: 'numeric',
@@ -11,6 +23,14 @@ export const toLocalizedDate = (date: Date, locale: string): string => {
 }
 
 export const toLocalizedDateString = (date: Date, locale: string): string => {
+  if (locale === 'ky-KG') {
+    // ky-KG has no support in chrome since has to opt for ru-RU lang as options as it's 99% readable in KG region
+    return date.toLocaleString('ru-RU', {
+      month: 'numeric',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
   return date.toLocaleString(locale, {
     month: 'numeric',
     day: 'numeric',
@@ -23,12 +43,21 @@ export const getOneLetterDayNames = (
   locale: string
 ): string[] => {
   return week.map((date) => {
+    if (locale === 'ky-KG') {
+      // ky-KG has no support in chrome since has to opt for ru-RU lang as options as it's 99% readable in KG region
+      return date.toLocaleString('ru-RU', { weekday: 'short' }).charAt(0)
+    }
     return date.toLocaleString(locale, { weekday: 'short' }).charAt(0)
   })
 }
 
-export const getDayNameShort = (date: Date, locale: string) =>
-  date.toLocaleString(locale, { weekday: 'short' })
+export const getDayNameShort = (date: Date, locale: string) => {
+  if (locale === 'ky-KG') {
+    // ky-KG has no support in chrome since has to opt for ru-RU lang as options as it's 99% readable in KG region
+    return date.toLocaleString('ru-RU', { weekday: 'short' })
+  }
+  return date.toLocaleString(locale, { weekday: 'short' })
+}
 
 export const getDayNamesShort = (week: Date[], locale: string): string[] => {
   return week.map((date) => getDayNameShort(date, locale))

--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -34,6 +34,8 @@ import { mkMK } from './locales/mk-MK'
 import { datePickerMkMK } from './locales/mk-MK/date-picker'
 import { trTR } from './locales/tr-TR'
 import { datePickerTrTR } from './locales/tr-TR/date-picker'
+import { kyKG } from './locales/ky-KG'
+import { datePickerKyKG } from './locales/ky-KG/date-picker'
 
 import { translate } from './translator/translate'
 
@@ -56,6 +58,7 @@ const translations = {
   ptBR,
   skSK,
   trTR,
+  kyKG,
 }
 
 const datePickerTranslations = {
@@ -76,7 +79,8 @@ const datePickerTranslations = {
   nlNL: datePickerNlNL,
   ptBR: datePickerPtBR,
   skSK: datePickerSkSK,
-  trTR, datePickerTrTR,
+  trTR: datePickerTrTR,
+  kyKG: datePickerKyKG,
 }
 
 export {
@@ -101,4 +105,5 @@ export {
   ptBR,
   skSK,
   trTR,
+  kyKG,
 }

--- a/packages/translations/src/locales/ky-KG/calendar.ts
+++ b/packages/translations/src/locales/ky-KG/calendar.ts
@@ -1,0 +1,16 @@
+import { CalendarTranslations } from '../../types/calendar.translations'
+
+export const calendarKyKG: CalendarTranslations = {
+  Today: 'Бүгүн',
+  Month: 'Ай',
+  Week: 'Апта',
+  Day: 'Күн',
+  events: 'Окуялар',
+  event: 'Окуя',
+  'No events': 'Окуя жок',
+  'Next period': 'Кийинки мезгил',
+  'Previous period': 'Өткөн мезгил',
+  to: 'чейин', // as in 2/1/2020 to 2/2/2020
+  'Full day- and multiple day events':
+    'Күн бою жана бир нече күн катары менен болгон окуялар',
+}

--- a/packages/translations/src/locales/ky-KG/date-picker.ts
+++ b/packages/translations/src/locales/ky-KG/date-picker.ts
@@ -1,0 +1,10 @@
+import { DatePickerTranslations } from '../../types/date-picker.translations'
+
+export const datePickerKyKG: DatePickerTranslations = {
+  Date: 'Датасы',
+  'MM/DD/YYYY': 'АА/КК/ЖЖЖЖ',
+  'Next month': 'Кийинки ай',
+  'Previous month': 'Өткөн ай',
+  'Choose Date': 'Күндү тандаңыз',
+  'Select View': 'Көрүнүштү тандаңыз',
+}

--- a/packages/translations/src/locales/ky-KG/index.ts
+++ b/packages/translations/src/locales/ky-KG/index.ts
@@ -1,0 +1,8 @@
+import { datePickerKyKG } from './date-picker'
+import { Language } from '../../types/language.translations'
+import { calendarKyKG } from './calendar'
+
+export const kyKG: Language = {
+  ...datePickerKyKG,
+  ...calendarKyKG,
+}

--- a/website/pages/docs/calendar/supported-languages.mdx
+++ b/website/pages/docs/calendar/supported-languages.mdx
@@ -4,7 +4,7 @@ Schedule-X currently supports the following languages. For support of further la
 your translations under the folder: `packages/translations/src/locales/xx-XX`
 
 | Language        | Code  |
-|-----------------|-------|
+| --------------- | ----- |
 | Chinese         | zh-CN |
 | Danish          | da-DK |
 | Dutch           | nl-NL |
@@ -23,3 +23,4 @@ your translations under the folder: `packages/translations/src/locales/xx-XX`
 | Spanish         | es-ES |
 | Swedish         | sv-SE |
 | Turkish         | tr-TR |
+| Kyrgyz          | ky-KG |


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [X] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [X] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [] If committing a new feature, I have also written the appropriate tests for it. 
- [X] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

## This PR solves the following problem**. 

- makes ru-RU locale months from lowercase to uppercase since the browser native .toLocaleString() output the month name with lower case
- opting the ky-KG to ru-RU language where it will affect only the names of [months, weeks] opting to this options will allow to freely use the calendar for users of ky-KG locale and this is could be a great temporary solution while as long as the following two issues exist:
  - Safari, FireFox has bugs which is reported by #354 issue
  - Chromium support for ky-KG awaiting and has no clear time when the issue reported in [334720108](https://issues.chromium.org/issues/334720108)
  - if the two issues are resolved then this feature can be removed
  
## How to test this PR**. 

For example:  
- testing ru-RU
1. config locale to ru-RU. 
2. open calendar and the month names starts with upper case 
- testing ky-KG
1. config locale to ky-KG.
2. open calendar on Safari, Opera, Chromium, FireFox and the month names are displayed in ru-RU language

  
