### PR TITLE
feat(optional custom month weekdays names): allow to add locale with …

### DIFF
--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -72,7 +72,7 @@ const calendar = createCalendar({
   // locale: 'ja-JP',
   // locale: 'en-US',
   // locale: 'zh-CN',
-  locale: 'ky-KG',
+  locale: 'kg-KG',
   views: [viewMonthGrid, viewWeek, viewDay, viewMonthAgenda],
   // defaultView: viewWeek.name,
   // minDate: '2024-01-01',

--- a/eslintrc.cjs
+++ b/eslintrc.cjs
@@ -63,7 +63,7 @@ module.exports = {
           },
           {
             from: 'shared',
-            allow: [],
+            allow: ['translations'],
           },
           {
             from: 'translations',

--- a/packages/calendar/src/utils/stateless/range-heading.ts
+++ b/packages/calendar/src/utils/stateless/range-heading.ts
@@ -1,12 +1,18 @@
 import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
 import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
+import { translate, translations } from '@schedule-x/translations/src'
 
-const getLocaleStringMonthArgs = ($app: CalendarAppSingleton) => {
-  return [$app.config.locale, { month: 'long' }] as const
+const getLocaleStringMonthArgs = (date: Date, $app: CalendarAppSingleton) => {
+  const language = translate($app.config.locale, translations)
+
+  if (language('monthsName') === 'monthsName') {
+    return date.toLocaleString($app.config.locale, { month: 'long' })
+  }
+  return language('monthsName')[date.getMonth()]
 }
 
-const getLocaleStringYearArgs = ($app: CalendarAppSingleton) => {
-  return [$app.config.locale, { year: 'numeric' }] as const
+const getLocaleStringYearArgs = (date: Date, $app: CalendarAppSingleton) => {
+  return date.toLocaleString($app.config.locale, { year: 'numeric' })
 }
 
 export const getMonthAndYearForDateRange = (
@@ -14,18 +20,10 @@ export const getMonthAndYearForDateRange = (
   rangeStart: string,
   rangeEnd: string
 ): string => {
-  const startDateMonth = toJSDate(rangeStart).toLocaleString(
-    ...getLocaleStringMonthArgs($app)
-  )
-  const startDateYear = toJSDate(rangeStart).toLocaleString(
-    ...getLocaleStringYearArgs($app)
-  )
-  const endDateMonth = toJSDate(rangeEnd).toLocaleString(
-    ...getLocaleStringMonthArgs($app)
-  )
-  const endDateYear = toJSDate(rangeEnd).toLocaleString(
-    ...getLocaleStringYearArgs($app)
-  )
+  const startDateMonth = getLocaleStringMonthArgs(toJSDate(rangeStart), $app)
+  const endDateMonth = getLocaleStringMonthArgs(toJSDate(rangeEnd), $app)
+  const startDateYear = getLocaleStringYearArgs(toJSDate(rangeStart), $app)
+  const endDateYear = getLocaleStringYearArgs(toJSDate(rangeEnd), $app)
 
   if (startDateMonth === endDateMonth && startDateYear === endDateYear) {
     return `${startDateMonth} ${startDateYear}`
@@ -37,12 +35,14 @@ export const getMonthAndYearForDateRange = (
 }
 
 export const getMonthAndYearForSelectedDate = ($app: CalendarAppSingleton) => {
-  const dateMonth = toJSDate(
-    $app.datePickerState.selectedDate.value
-  ).toLocaleString(...getLocaleStringMonthArgs($app))
-  const dateYear = toJSDate(
-    $app.datePickerState.selectedDate.value
-  ).toLocaleString(...getLocaleStringYearArgs($app))
+  const dateMonth = getLocaleStringMonthArgs(
+    toJSDate($app.datePickerState.selectedDate.value),
+    $app
+  )
+  const dateYear = getLocaleStringYearArgs(
+    toJSDate($app.datePickerState.selectedDate.value),
+    $app
+  )
 
   return `${dateMonth} ${dateYear}`
 }

--- a/packages/shared/src/utils/stateless/time/date-time-localization/date-time-localization.ts
+++ b/packages/shared/src/utils/stateless/time/date-time-localization/date-time-localization.ts
@@ -1,13 +1,25 @@
+import { translate, translations } from '@schedule-x/translations/src'
+
 export const toLocalizedMonth = (date: Date, locale: string): string => {
-  return date.toLocaleString(locale, { month: 'long' })
+  const language = translate(locale, translations)
+
+  if (language('monthsName') === 'monthsName') {
+    return date.toLocaleString(locale, { month: 'long' })
+  }
+  return language('monthsName')[date.getMonth()]
 }
 
 export const toLocalizedDate = (date: Date, locale: string): string => {
-  return date.toLocaleString(locale, {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  })
+  const language = translate(locale, translations)
+
+  if (language('monthsName') === 'monthsName') {
+    return date.toLocaleString(locale, {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
+  return `${date.getDay()} ${toLocalizedMonth(date, locale)} ${date.getFullYear()}`
 }
 
 export const toLocalizedDateString = (date: Date, locale: string): string => {
@@ -22,13 +34,26 @@ export const getOneLetterDayNames = (
   week: Date[],
   locale: string
 ): string[] => {
+  const language = translate(locale, translations)
+
+  if (language('monthsName') === 'monthsName') {
+    return week.map((date) => {
+      return date.toLocaleString(locale, { weekday: 'short' }).charAt(0)
+    })
+  }
   return week.map((date) => {
-    return date.toLocaleString(locale, { weekday: 'short' }).charAt(0)
+    return language('weekdaysName')[date.getDay()].charAt(0)
   })
 }
 
-export const getDayNameShort = (date: Date, locale: string) =>
-  date.toLocaleString(locale, { weekday: 'short' })
+export const getDayNameShort = (date: Date, locale: string) => {
+  const language = translate(locale, translations)
+
+  if (language('monthsName') === 'monthsName') {
+    return date.toLocaleString(locale, { weekday: 'short' })
+  }
+  return language('weekdaysName')[date.getDay()].slice(0, 3)
+}
 
 export const getDayNamesShort = (week: Date[], locale: string): string[] => {
   return week.map((date) => getDayNameShort(date, locale))

--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -34,8 +34,8 @@ import { mkMK } from './locales/mk-MK'
 import { datePickerMkMK } from './locales/mk-MK/date-picker'
 import { trTR } from './locales/tr-TR'
 import { datePickerTrTR } from './locales/tr-TR/date-picker'
-import { kyKG } from './locales/ky-KG'
-import { datePickerKyKG } from './locales/ky-KG/date-picker'
+import { kgKG } from './locales/kg-KG'
+import { datePickerKgKG } from './locales/kg-KG/date-picker'
 
 import { translate } from './translator/translate'
 
@@ -58,7 +58,7 @@ const translations = {
   ptBR,
   skSK,
   trTR,
-  kyKG,
+  kgKG,
 }
 
 const datePickerTranslations = {
@@ -80,7 +80,7 @@ const datePickerTranslations = {
   ptBR: datePickerPtBR,
   skSK: datePickerSkSK,
   trTR: datePickerTrTR,
-  kyKG: datePickerKyKG,
+  kgKG: datePickerKgKG,
 }
 
 export {
@@ -105,5 +105,5 @@ export {
   ptBR,
   skSK,
   trTR,
-  kyKG,
+  kgKG,
 }

--- a/packages/translations/src/locales/kg-KG/calendar.ts
+++ b/packages/translations/src/locales/kg-KG/calendar.ts
@@ -1,6 +1,6 @@
 import { CalendarTranslations } from '../../types/calendar.translations'
 
-export const calendarKyKG: CalendarTranslations = {
+export const calendarKgKG: CalendarTranslations = {
   Today: 'Бүгүн',
   Month: 'Ай',
   Week: 'Апта',

--- a/packages/translations/src/locales/kg-KG/date-picker.ts
+++ b/packages/translations/src/locales/kg-KG/date-picker.ts
@@ -1,6 +1,6 @@
 import { DatePickerTranslations } from '../../types/date-picker.translations'
 
-export const datePickerKyKG: DatePickerTranslations = {
+export const datePickerKgKG: DatePickerTranslations = {
   Date: 'Датасы',
   'MM/DD/YYYY': 'АА/КК/ЖЖЖЖ',
   'Next month': 'Кийинки ай',

--- a/packages/translations/src/locales/kg-KG/index.ts
+++ b/packages/translations/src/locales/kg-KG/index.ts
@@ -1,0 +1,10 @@
+import { datePickerKgKG } from './date-picker'
+import { Language } from '../../types/language.translations'
+import { calendarKgKG } from './calendar'
+import { monthsWeekdaysKgKG } from './months-weekdays'
+
+export const kgKG: Language = {
+  ...datePickerKgKG,
+  ...calendarKgKG,
+  ...monthsWeekdaysKgKG,
+}

--- a/packages/translations/src/locales/kg-KG/months-weekdays.ts
+++ b/packages/translations/src/locales/kg-KG/months-weekdays.ts
@@ -7,5 +7,5 @@ export const monthsWeekdaysKgKG: MonthsWeekdaysTranslations = {
       '_'
     ),
   weekdaysName:
-    'Жекшемби_Дүйшөмбү_Шейшемби_Шаршемби_Бейшемби_Жума_Ишемби'.split('_'),
+    'Дүйшөмбү_Шейшемби_Шаршемби_Бейшемби_Жума_Ишемби_Жекшемби'.split('_'),
 }

--- a/packages/translations/src/locales/kg-KG/months-weekdays.ts
+++ b/packages/translations/src/locales/kg-KG/months-weekdays.ts
@@ -2,10 +2,9 @@ import { MonthsWeekdaysTranslations } from '../../types/months-weeks.translation
 
 export const monthsWeekdaysKgKG: MonthsWeekdaysTranslations = {
   monthsName:
-    // 'Январь_Февраль_Март_Апрель_Май_Июнь_Июль_Август_Сентябрь_Октябрь_Ноябрь_Декабрь'.split(
     'Үчтүн айы_Бирдин айы_Жалган Куран_Чын Куран_Бугу_Кулжа_Теке_Баш Оона_Аяк Оона_Тогуздун айы_Жетинин айы_Бештин айы'.split(
       '_'
     ),
   weekdaysName:
-    'Дүйшөмбү_Шейшемби_Шаршемби_Бейшемби_Жума_Ишемби_Жекшемби'.split('_'),
+    'Жекшемби_Дүйшөмбү_Шейшемби_Шаршемби_Бейшемби_Жума_Ишемби'.split('_'),
 }

--- a/packages/translations/src/locales/kg-KG/months-weekdays.ts
+++ b/packages/translations/src/locales/kg-KG/months-weekdays.ts
@@ -1,0 +1,11 @@
+import { MonthsWeekdaysTranslations } from '../../types/months-weeks.translations'
+
+export const monthsWeekdaysKgKG: MonthsWeekdaysTranslations = {
+  monthsName:
+    // 'Январь_Февраль_Март_Апрель_Май_Июнь_Июль_Август_Сентябрь_Октябрь_Ноябрь_Декабрь'.split(
+    'Үчтүн айы_Бирдин айы_Жалган Куран_Чын Куран_Бугу_Кулжа_Теке_Баш Оона_Аяк Оона_Тогуздун айы_Жетинин айы_Бештин айы'.split(
+      '_'
+    ),
+  weekdaysName:
+    'Жекшемби_Дүйшөмбү_Шейшемби_Шаршемби_Бейшемби_Жума_Ишемби'.split('_'),
+}

--- a/packages/translations/src/locales/ky-KG/index.ts
+++ b/packages/translations/src/locales/ky-KG/index.ts
@@ -1,8 +1,0 @@
-import { datePickerKyKG } from './date-picker'
-import { Language } from '../../types/language.translations'
-import { calendarKyKG } from './calendar'
-
-export const kyKG: Language = {
-  ...datePickerKyKG,
-  ...calendarKyKG,
-}

--- a/packages/translations/src/types/language.translations.ts
+++ b/packages/translations/src/types/language.translations.ts
@@ -1,4 +1,7 @@
 import { DatePickerTranslations } from './date-picker.translations'
 import { CalendarTranslations } from './calendar.translations'
+import { MonthsWeekdaysTranslations } from './months-weeks.translations'
 
-export type Language = DatePickerTranslations & CalendarTranslations
+export type Language = DatePickerTranslations &
+  CalendarTranslations &
+  Partial<MonthsWeekdaysTranslations>

--- a/packages/translations/src/types/months-weeks.translations.ts
+++ b/packages/translations/src/types/months-weeks.translations.ts
@@ -1,0 +1,4 @@
+export interface MonthsWeekdaysTranslations {
+  monthsName: string[]
+  weekdaysName: string[]
+}

--- a/website/pages/docs/calendar/supported-languages.mdx
+++ b/website/pages/docs/calendar/supported-languages.mdx
@@ -15,7 +15,7 @@ your translations under the folder: `packages/translations/src/locales/xx-XX`
 | Italian         | it-IT |
 | Japanese        | ja-JP |
 | Korean          | ko-KR |
-| Kyrgyz          | ky-KG |
+| Kyrgyz          | kg-KG |
 | Macedonian      | mk-MK |
 | Polish          | pl-PL |
 | Portuguese (BR) | pt-BR |


### PR DESCRIPTION
…optional monthsweeks names

## Checklist

Please put "X" in the below checkboxes that apply:

- [x] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [x] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [X] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

## This PR solves the following problem**. 

#351 
#354 


## How to test this PR**. 

For example:  
1. config locale to kg-KG
2. open in different browser 
3. May confirm by interacting the calendar navigation. 


## This feature allows for developers who faces the limitation support of their locales in the browsers and provide the choice to opt for custom names for months and weekdays 
