### PR TITLE
Feat/leading trailing date

### DIFF
--- a/packages/calendar/src/utils/stateless/range-heading.ts
+++ b/packages/calendar/src/utils/stateless/range-heading.ts
@@ -1,8 +1,12 @@
 import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
 import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
+type Locale = 'long' | 'numeric'
 
-const getLocaleStringMonthArgs = ($app: CalendarAppSingleton) => {
-  return [$app.config.locale, { month: 'long' }] as const
+export const getLocaleStringMonthArgs = (
+  $app: CalendarAppSingleton,
+  local: Locale = 'long'
+) => {
+  return [$app.config.locale, { month: local }] as const
 }
 
 const getLocaleStringYearArgs = ($app: CalendarAppSingleton) => {

--- a/packages/calendar/src/utils/stateless/range-heading.ts
+++ b/packages/calendar/src/utils/stateless/range-heading.ts
@@ -1,7 +1,7 @@
 import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
 import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
 
-export const getLocaleStringMonthArgs = ($app: CalendarAppSingleton) => {
+const getLocaleStringMonthArgs = ($app: CalendarAppSingleton) => {
   return [$app.config.locale, { month: 'long' }] as const
 }
 

--- a/packages/calendar/src/utils/stateless/range-heading.ts
+++ b/packages/calendar/src/utils/stateless/range-heading.ts
@@ -1,12 +1,8 @@
 import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
 import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
-type Locale = 'long' | 'numeric'
 
-export const getLocaleStringMonthArgs = (
-  $app: CalendarAppSingleton,
-  local: Locale = 'long'
-) => {
-  return [$app.config.locale, { month: local }] as const
+export const getLocaleStringMonthArgs = ($app: CalendarAppSingleton) => {
+  return [$app.config.locale, { month: 'long' }] as const
 }
 
 const getLocaleStringYearArgs = ($app: CalendarAppSingleton) => {

--- a/packages/calendar/src/views/month-agenda/components/__test__/month-agenda-day.spec.tsx
+++ b/packages/calendar/src/views/month-agenda/components/__test__/month-agenda-day.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import {
   describe,
   it,
@@ -10,18 +11,23 @@ import { MonthAgendaDay as MonthAgendaDayType } from '../../types/month-agenda'
 import { StateUpdater } from 'preact/hooks'
 import { vi } from 'vitest'
 import { __createAppWithViews__ } from '../../../../utils/stateless/testing/__create-app-with-views__'
+import { CalendarAppSingleton } from '@schedule-x/shared/src'
+import { AppContext } from '../../../../utils/stateful/app-context'
 
 const renderComponent = (
+  $app: CalendarAppSingleton,
   day: MonthAgendaDayType,
   isActive = false,
   setActiveDate: StateUpdater<string> = vi.fn
 ) => {
   render(
-    <MonthAgendaDay
-      day={day}
-      isActive={isActive}
-      setActiveDate={setActiveDate}
-    />
+    <AppContext.Provider value={$app}>
+      <MonthAgendaDay
+        day={day}
+        isActive={isActive}
+        setActiveDate={setActiveDate}
+      />
+    </AppContext.Provider>
   )
 }
 
@@ -36,13 +42,21 @@ describe('MonthAgendaDay', () => {
 
   describe('the active state', () => {
     it('should have an active class', () => {
-      renderComponent({ date: '2020-01-01', events: [] }, true)
+      renderComponent(
+        __createAppWithViews__(),
+        { date: '2020-01-01', events: [] },
+        true
+      )
 
       expect(document.querySelector(ACTIVE_DAY_SELECTOR)).not.toBeNull()
     })
 
     it('should not have an active class', () => {
-      renderComponent({ date: '2020-01-01', events: [] }, false)
+      renderComponent(
+        __createAppWithViews__(),
+        { date: '2020-01-01', events: [] },
+        false
+      )
 
       expect(document.querySelector(ACTIVE_DAY_SELECTOR)).toBeNull()
     })
@@ -52,7 +66,12 @@ describe('MonthAgendaDay', () => {
     it('should call setActiveDate with the date', () => {
       const setActiveDate = vi.fn()
       const date = '2020-01-01'
-      renderComponent({ date, events: [] }, false, setActiveDate)
+      renderComponent(
+        __createAppWithViews__(),
+        { date, events: [] },
+        false,
+        setActiveDate
+      )
 
       fireEvent.click(document.querySelector(DAY_SELECTOR) as Element)
 
@@ -65,7 +84,7 @@ describe('MonthAgendaDay', () => {
       const $app = __createAppWithViews__({
         events: [],
       })
-      renderComponent({
+      renderComponent($app, {
         date: '2020-01-01',
         events: $app.calendarEvents.list.value,
       })
@@ -77,7 +96,7 @@ describe('MonthAgendaDay', () => {
       const $app = __createAppWithViews__({
         events: [{ id: 1, start: '2020-01-01', end: '2020-01-01' }],
       })
-      renderComponent({
+      renderComponent($app, {
         date: '2020-01-01',
         events: $app.calendarEvents.list.value,
       })
@@ -93,7 +112,7 @@ describe('MonthAgendaDay', () => {
           { id: 3, start: '2020-01-01', end: '2020-01-01' },
         ],
       })
-      renderComponent({
+      renderComponent($app, {
         date: '2020-01-01',
         events: $app.calendarEvents.list.value,
       })
@@ -110,12 +129,41 @@ describe('MonthAgendaDay', () => {
           { id: 4, start: '2020-01-01', end: '2020-01-01' },
         ],
       })
-      renderComponent({
+      renderComponent($app, {
         date: '2020-01-01',
         events: $app.calendarEvents.list.value,
       })
 
       expect(document.querySelectorAll(EVENT_ICON_SELECTOR).length).toBe(3)
+    })
+  })
+
+  describe('setting classes for leading and trailing dates', () => {
+    it('should not show any leading and trailing classes', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: '2021-02-01',
+      })
+      renderComponent($app, { date: '2021-02-01', events: [] })
+
+      expect(document.querySelector('.is-leading-or-trailing')).toBeNull()
+    })
+
+    it('should set a class for being a leading date', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: '2021-04-01',
+      })
+      renderComponent($app, { date: '2021-03-31', events: [] })
+
+      expect(document.querySelector('.is-leading-or-trailing')).not.toBeNull()
+    })
+
+    it('should set a class for being a trailing date', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: '2021-04-01',
+      })
+      renderComponent($app, { date: '2021-05-01', events: [] })
+
+      expect(document.querySelector('.is-leading-or-trailing')).not.toBeNull()
     })
   })
 })

--- a/packages/calendar/src/views/month-agenda/components/month-agenda-day.tsx
+++ b/packages/calendar/src/views/month-agenda/components/month-agenda-day.tsx
@@ -1,6 +1,8 @@
 import { MonthAgendaDay as MonthAgendaDayType } from '../types/month-agenda'
 import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
-import { StateUpdater } from 'preact/hooks'
+import { StateUpdater, useContext } from 'preact/hooks'
+import { AppContext } from '../../../utils/stateful/app-context'
+import { getLocaleStringMonthArgs } from '../../../utils/stateless/range-heading'
 
 type props = {
   day: MonthAgendaDayType
@@ -13,8 +15,19 @@ export default function MonthAgendaDay({
   isActive,
   setActiveDate,
 }: props) {
+  const $app = useContext(AppContext)
+
+  const monthSelected = toJSDate(
+    $app.datePickerState.selectedDate.value
+  ).toLocaleString(...getLocaleStringMonthArgs($app, 'numeric'))
+
+  const currentMonth = toJSDate(day.date).getMonth()
+  const isDateOfPreviousMonth = Number(monthSelected) - 1 < currentMonth
+  const isDateOfNextMonth = Number(monthSelected) - 1 > currentMonth
   const dayClasses = ['sx__month-agenda-day']
   if (isActive) dayClasses.push('sx__month-agenda-day--active')
+  if (isDateOfPreviousMonth) dayClasses.push('sx__is-leading-date')
+  if (isDateOfNextMonth) dayClasses.push('sx__is-trailing-date')
 
   return (
     <div

--- a/packages/calendar/src/views/month-agenda/components/month-agenda-day.tsx
+++ b/packages/calendar/src/views/month-agenda/components/month-agenda-day.tsx
@@ -1,8 +1,10 @@
 import { MonthAgendaDay as MonthAgendaDayType } from '../types/month-agenda'
-import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
+import {
+  toIntegers,
+  toJSDate,
+} from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
 import { StateUpdater, useContext } from 'preact/hooks'
 import { AppContext } from '../../../utils/stateful/app-context'
-import { getLocaleStringMonthArgs } from '../../../utils/stateless/range-heading'
 
 type props = {
   day: MonthAgendaDayType
@@ -17,17 +19,14 @@ export default function MonthAgendaDay({
 }: props) {
   const $app = useContext(AppContext)
 
-  const monthSelected = toJSDate(
+  const { month: monthSelected } = toIntegers(
     $app.datePickerState.selectedDate.value
-  ).toLocaleString(...getLocaleStringMonthArgs($app, 'numeric'))
+  )
 
-  const currentMonth = toJSDate(day.date).getMonth()
-  const isDateOfPreviousMonth = Number(monthSelected) - 1 < currentMonth
-  const isDateOfNextMonth = Number(monthSelected) - 1 > currentMonth
+  const { month: monthOfDay } = toIntegers(day.date)
   const dayClasses = ['sx__month-agenda-day']
   if (isActive) dayClasses.push('sx__month-agenda-day--active')
-  if (isDateOfPreviousMonth) dayClasses.push('sx__is-leading-date')
-  if (isDateOfNextMonth) dayClasses.push('sx__is-trailing-date')
+  if (monthOfDay !== monthSelected) dayClasses.push('is-leading-or-trailing')
 
   return (
     <div


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [x] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [x] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

## This PR solves the following problem**. 
Added new class name: sx__is-leading-date, sx__is-trailing-date
This PR solved this problem in this issue https://github.com/schedule-x/schedule-x/issues/360

## How to test this PR**. 

1. Go to the calendar with mobile mode then enter `month-agenda` to view mode and set view.
2. Calendar will appear and will show news class name `sx__is-leading-date` or `sx__is-trailing-date` or both based on the date we selected
<img width="1438" alt="Screenshot 2024-04-17 at 08 47 50" src="https://github.com/schedule-x/schedule-x/assets/14916970/dcaa1dfd-9ce6-4d8c-825c-d32780b00501">

## Sample style
`.sx__is-leading-date, .sx__is-trailing-date {
  visibility: hidden;
}`
## Result
![Screenshot 2024-04-16 at 17 01 38](https://github.com/schedule-x/schedule-x/assets/14916970/fce71fca-018c-4582-880c-3f47757d3f16)
