### PR TITLE
feat(calendar): toggle responsiveness and pass custom break point function

### DIFF
--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -131,6 +131,10 @@ const calendar = createCalendar({
     onDoubleClickDate(date) {
       console.log('onDoubleClickDate', date)
     },
+
+    isCalendarSmall($app) {
+      return $app.elements.calendarWrapper?.clientWidth! < 500
+    }
   },
   calendars: {
     personal: {

--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -133,7 +133,7 @@ const calendar = createCalendar({
     },
 
     isCalendarSmall($app) {
-      return $app.elements.calendarWrapper?.clientWidth! < 500
+      return $app.elements.calendarWrapper!.clientWidth! < 500
     }
   },
   calendars: {

--- a/packages/calendar/src/components/calendar-wrapper.tsx
+++ b/packages/calendar/src/components/calendar-wrapper.tsx
@@ -31,11 +31,13 @@ export default function CalendarWrapper({ $app }: props) {
     handleWindowResize($app)
   }
 
-  useEffect(() => {
-    onResize()
-    window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
-  }, [])
+  if ($app.config.isResponsive) {
+    useEffect(() => {
+      onResize()
+      window.addEventListener('resize', onResize)
+      return () => window.removeEventListener('resize', onResize)
+    }, [])
+  }
 
   const wrapperClasses = useWrapperClasses($app)
 

--- a/packages/calendar/src/components/calendar-wrapper.tsx
+++ b/packages/calendar/src/components/calendar-wrapper.tsx
@@ -31,13 +31,13 @@ export default function CalendarWrapper({ $app }: props) {
     handleWindowResize($app)
   }
 
-  if ($app.config.isResponsive) {
-    useEffect(() => {
+  useEffect(() => {
+    if ($app.config.isResponsive) {
       onResize()
       window.addEventListener('resize', onResize)
       return () => window.removeEventListener('resize', onResize)
-    }, [])
-  }
+    }
+  }, [])
 
   const wrapperClasses = useWrapperClasses($app)
 

--- a/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
@@ -31,7 +31,6 @@ export default class CalendarConfigBuilder
   plugins: Plugins = {}
   isDark: boolean | undefined = false
   isResponsive: boolean | undefined = true
-  customBreakpointFunction: Function | undefined = undefined
   callbacks: CalendarCallbacks | undefined
   minDate: string | undefined
   maxDate: string | undefined
@@ -48,7 +47,6 @@ export default class CalendarConfigBuilder
       this.plugins,
       this.isDark,
       this.isResponsive,
-      this.customBreakpointFunction,
       this.callbacks,
       {},
       this.minDate,
@@ -120,11 +118,6 @@ export default class CalendarConfigBuilder
 
   withIsResponsive(isDark: boolean | undefined): CalendarConfigBuilder {
     this.isResponsive = isDark
-    return this
-  }
-
-  withCustomBreakpointFunction(customBreakpointFuntion: Function | undefined): CalendarConfigBuilder {
-    this.customBreakpointFunction = customBreakpointFuntion
     return this
   }
 

--- a/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
@@ -31,6 +31,7 @@ export default class CalendarConfigBuilder
   plugins: Plugins = {}
   isDark: boolean | undefined = false
   isResponsive: boolean | undefined = true
+  customBreakpointFunction: Function | undefined = undefined
   callbacks: CalendarCallbacks | undefined
   minDate: string | undefined
   maxDate: string | undefined
@@ -47,6 +48,7 @@ export default class CalendarConfigBuilder
       this.plugins,
       this.isDark,
       this.isResponsive,
+      this.customBreakpointFunction,
       this.callbacks,
       {},
       this.minDate,
@@ -118,6 +120,11 @@ export default class CalendarConfigBuilder
 
   withIsResponsive(isDark: boolean | undefined): CalendarConfigBuilder {
     this.isResponsive = isDark
+    return this
+  }
+
+  withCustomBreakpointFunction(customBreakpointFuntion: Function | undefined): CalendarConfigBuilder {
+    this.customBreakpointFunction = customBreakpointFuntion
     return this
   }
 

--- a/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
@@ -30,6 +30,7 @@ export default class CalendarConfigBuilder
   calendars: Record<string, CalendarType> | undefined
   plugins: Plugins = {}
   isDark: boolean | undefined = false
+  isResponsive: boolean | undefined = true
   callbacks: CalendarCallbacks | undefined
   minDate: string | undefined
   maxDate: string | undefined
@@ -45,6 +46,7 @@ export default class CalendarConfigBuilder
       this.calendars,
       this.plugins,
       this.isDark,
+      this.isResponsive,
       this.callbacks,
       {},
       this.minDate,
@@ -111,6 +113,11 @@ export default class CalendarConfigBuilder
 
   withIsDark(isDark: boolean | undefined): CalendarConfigBuilder {
     this.isDark = isDark
+    return this
+  }
+
+  withIsResponsive(isDark: boolean | undefined): CalendarConfigBuilder {
+    this.isResponsive = isDark
     return this
   }
 

--- a/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
@@ -34,6 +34,7 @@ export default class CalendarConfigImpl implements CalendarConfigInternal {
     calendars = {},
     public plugins = {},
     public isDark = false,
+    public isResponsive = true,
     public callbacks = {},
     public _customComponentFns = {},
     public minDate: string | undefined = undefined,

--- a/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
@@ -35,6 +35,7 @@ export default class CalendarConfigImpl implements CalendarConfigInternal {
     public plugins = {},
     public isDark = false,
     public isResponsive = true,
+    public customBreakpointFunction: Function | undefined = undefined,
     public callbacks = {},
     public _customComponentFns = {},
     public minDate: string | undefined = undefined,

--- a/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
@@ -35,7 +35,6 @@ export default class CalendarConfigImpl implements CalendarConfigInternal {
     public plugins = {},
     public isDark = false,
     public isResponsive = true,
-    public customBreakpointFunction: Function | undefined = undefined,
     public callbacks = {},
     public _customComponentFns = {},
     public minDate: string | undefined = undefined,

--- a/packages/calendar/src/utils/stateless/dom/__test__/handle-window-resize.spec.ts
+++ b/packages/calendar/src/utils/stateless/dom/__test__/handle-window-resize.spec.ts
@@ -18,6 +18,7 @@ describe('handle window resize', () => {
       $app.config = {
         ...stubInterface(),
         views: [viewDay, viewMonthGrid],
+        callbacks: {},
       }
       document.documentElement.style.fontSize = '16px'
       $app.calendarState = {
@@ -46,6 +47,40 @@ describe('handle window resize', () => {
         'day',
         $app.datePickerState.selectedDate.value
       )
+    })
+
+    it('should call the isCalendarSmall callback', () => {
+      const $app = stubInterface<CalendarAppSingleton>()
+      $app.config = {
+        ...stubInterface(),
+        views: [viewDay, viewMonthGrid],
+        callbacks: {
+          isCalendarSmall: vi.fn(),
+        },
+      }
+      document.documentElement.style.fontSize = '16px'
+      $app.calendarState = {
+        ...stubInterface(),
+        isCalendarSmall: signal(false),
+        view: signal('month-grid'),
+        setRange: vi.fn(),
+        setView: vi.fn(),
+      }
+      $app.elements = {
+        calendarWrapper: {
+          ...stubInterface<HTMLDivElement>(),
+          clientWidth: 699,
+        },
+      }
+      $app.datePickerState = {
+        ...stubInterface(),
+        selectedDate: signal('2021-01-01'),
+      }
+      expect($app.calendarState.view.value).toBe('month-grid')
+
+      handleWindowResize($app)
+
+      expect($app.config.callbacks.isCalendarSmall).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/calendar/src/utils/stateless/dom/handle-window-resize.ts
+++ b/packages/calendar/src/utils/stateless/dom/handle-window-resize.ts
@@ -47,7 +47,9 @@ export const handleWindowResize = ($app: CalendarAppSingleton) => {
 
   if (!calendarRoot) return
 
-  const isSmall = $app.config.customBreakpointFunction ? $app.config.customBreakpointFunction() : calendarRoot.clientWidth < smallCalendarBreakpoint
+  const isSmall = $app.config.callbacks.isCalendarSmall
+    ? $app.config.callbacks.isCalendarSmall($app)
+    : calendarRoot.clientWidth < smallCalendarBreakpoint
   const didIsSmallScreenChange =
     isSmall !== $app.calendarState.isCalendarSmall.value
   if (!didIsSmallScreenChange) return

--- a/packages/calendar/src/utils/stateless/dom/handle-window-resize.ts
+++ b/packages/calendar/src/utils/stateless/dom/handle-window-resize.ts
@@ -47,7 +47,7 @@ export const handleWindowResize = ($app: CalendarAppSingleton) => {
 
   if (!calendarRoot) return
 
-  const isSmall = calendarRoot.clientWidth < smallCalendarBreakpoint
+  const isSmall = $app.config.customBreakpointFunction ? $app.config.customBreakpointFunction() : calendarRoot.clientWidth < smallCalendarBreakpoint
   const didIsSmallScreenChange =
     isSmall !== $app.calendarState.isCalendarSmall.value
   if (!didIsSmallScreenChange) return

--- a/packages/calendar/src/utils/stateless/factories/create-internal-config.ts
+++ b/packages/calendar/src/utils/stateless/factories/create-internal-config.ts
@@ -13,7 +13,6 @@ export const createInternalConfig = (config: CalendarConfigExternal) => {
     .withPlugins(config.plugins)
     .withIsDark(config.isDark)
     .withIsResponsive(config.isResponsive)
-    .withCustomBreakpointFunction(config.customBreakpointFunction)
     .withCallbacks(config.callbacks)
     .withMinDate(config.minDate)
     .withMaxDate(config.maxDate)

--- a/packages/calendar/src/utils/stateless/factories/create-internal-config.ts
+++ b/packages/calendar/src/utils/stateless/factories/create-internal-config.ts
@@ -13,6 +13,7 @@ export const createInternalConfig = (config: CalendarConfigExternal) => {
     .withPlugins(config.plugins)
     .withIsDark(config.isDark)
     .withIsResponsive(config.isResponsive)
+    .withCustomBreakpointFunction(config.customBreakpointFunction)
     .withCallbacks(config.callbacks)
     .withMinDate(config.minDate)
     .withMaxDate(config.maxDate)

--- a/packages/calendar/src/utils/stateless/factories/create-internal-config.ts
+++ b/packages/calendar/src/utils/stateless/factories/create-internal-config.ts
@@ -12,6 +12,7 @@ export const createInternalConfig = (config: CalendarConfigExternal) => {
     .withCalendars(config.calendars)
     .withPlugins(config.plugins)
     .withIsDark(config.isDark)
+    .withIsResponsive(config.isResponsive)
     .withCallbacks(config.callbacks)
     .withMinDate(config.minDate)
     .withMaxDate(config.maxDate)

--- a/packages/shared/src/interfaces/calendar/calendar-config.ts
+++ b/packages/shared/src/interfaces/calendar/calendar-config.ts
@@ -61,7 +61,6 @@ export default interface CalendarConfigInternal extends Config {
   plugins: Plugins
   isDark: boolean
   isResponsive: boolean
-  customBreakpointFunction?: Function
   callbacks: CalendarCallbacks
   _customComponentFns: CustomComponentFns
   minDate?: string

--- a/packages/shared/src/interfaces/calendar/calendar-config.ts
+++ b/packages/shared/src/interfaces/calendar/calendar-config.ts
@@ -61,6 +61,7 @@ export default interface CalendarConfigInternal extends Config {
   plugins: Plugins
   isDark: boolean
   isResponsive: boolean
+  customBreakpointFunction?: Function
   callbacks: CalendarCallbacks
   _customComponentFns: CustomComponentFns
   minDate?: string

--- a/packages/shared/src/interfaces/calendar/calendar-config.ts
+++ b/packages/shared/src/interfaces/calendar/calendar-config.ts
@@ -60,6 +60,7 @@ export default interface CalendarConfigInternal extends Config {
   calendars: Signal<Record<string, CalendarType>>
   plugins: Plugins
   isDark: boolean
+  isResponsive: boolean
   callbacks: CalendarCallbacks
   _customComponentFns: CustomComponentFns
   minDate?: string

--- a/packages/shared/src/interfaces/calendar/listeners.interface.ts
+++ b/packages/shared/src/interfaces/calendar/listeners.interface.ts
@@ -1,5 +1,6 @@
 import CalendarEventExternal from './calendar-event.interface'
 import { DateRange } from '../../types/date-range'
+import CalendarAppSingleton from './calendar-app-singleton'
 
 export interface CalendarCallbacks {
   onEventUpdate?: (event: CalendarEventExternal) => void
@@ -12,4 +13,6 @@ export interface CalendarCallbacks {
   onDoubleClickDateTime?: (dateTime: string) => void
   onClickAgendaDate?: (date: string) => void
   onClickPlusEvents?: (date: string) => void
+
+  isCalendarSmall?: ($app: CalendarAppSingleton) => boolean
 }

--- a/website/pages/docs/calendar/configuration.mdx
+++ b/website/pages/docs/calendar/configuration.mdx
@@ -39,19 +39,6 @@ const config = {
    * */
   defaultView: viewMonthGrid.name,
 
-   /**
-   * Toggle automatic view change when the calendar is resized below a certain width breakpoint.
-   * Defaults to true
-   * */
-  isResponsive: false,
-
-   /**
-   * Pass a function that will be used to calculate a break point used for calculating the current view type.
-   * Given standard browser settings where 1rem = 16px, the calendar has an default break point of 700px.
-   * More information on the default function: https://schedule-x.dev/docs/calendar/views#a-note-on-screen-sizes
-   * */
-  customBreakpointFunction: () => window.innerWidth <= 800,
-
   /**
    * The default date to display when the calendar is first rendered. Only accepts YYYY-MM-DD format.
    * Defaults to the current date
@@ -94,6 +81,12 @@ const config = {
     * */
     nEventsPerDay: 8
   },
+
+  /**
+   * Toggle automatic view change when the calendar is resized below a certain width breakpoint.
+   * Defaults to true
+   * */
+  isResponsive: false,
 
   /**
    * Callbacks for events that occur in the calendar
@@ -171,6 +164,15 @@ const config = {
     onSelectedDateUpdate(date) {
       console.log('onSelectedDateUpdate', date)
     },
+
+
+    /**
+     * Runs on resizing the calendar, to decide if the calendar should be small or not.
+     * This in turn affects what views are rendered.
+     * */
+    isCalendarSmall($app) {
+      return $app.elements.calendarWrapper?.clientWidth! < 500
+    }
   },
 }
 

--- a/website/pages/docs/calendar/configuration.mdx
+++ b/website/pages/docs/calendar/configuration.mdx
@@ -39,6 +39,19 @@ const config = {
    * */
   defaultView: viewMonthGrid.name,
 
+   /**
+   * Toggle automatic view change when the calendar is resized below a certain width breakpoint.
+   * Defaults to true
+   * */
+  isResponsive: false,
+
+   /**
+   * Pass a function that will be used to calculate a break point used for calculating the current view type.
+   * Given standard browser settings where 1rem = 16px, the calendar has an default break point of 700px.
+   * More information on the default function: https://schedule-x.dev/docs/calendar/views#a-note-on-screen-sizes
+   * */
+  customBreakpointFunction: () => window.innerWidth <= 800,
+
   /**
    * The default date to display when the calendar is first rendered. Only accepts YYYY-MM-DD format.
    * Defaults to the current date


### PR DESCRIPTION
## Checklist

- [x] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [X] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 


## This PR solves the following problem**. 

adds ability to toggle responsiveness of calendar (resizing on change of viewport width) and the option to pass a custom break point function that even this break point.

reference our chat on Discord
authors:  @struvelig & @malteamlimit