### PR TITLE
feat(calendar): Annual view agenda mode

### DIFF
--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -11,6 +11,7 @@ import {
   viewMonthGrid,
   viewDay,
   viewMonthAgenda,
+  viewYearAgenda,
 } from '@schedule-x/calendar/src'
 import '../../packages/theme-default/src/calendar.scss'
 import '../app.css'
@@ -19,7 +20,10 @@ import { createEventModalPlugin } from '@schedule-x/event-modal/src'
 import { seededEvents } from '../data/seeded-events.ts'
 import { createScrollControllerPlugin } from '@schedule-x/scroll-controller/src'
 import { createResizePlugin } from '../../packages/resize/src'
-import { createEventRecurrencePlugin, createEventsServicePlugin } from '@schedule-x/event-recurrence/src'
+import {
+  createEventRecurrencePlugin,
+  createEventsServicePlugin,
+} from '@schedule-x/event-recurrence/src'
 import { createCalendarControlsPlugin } from '../../packages/calendar-controls/src'
 import { CalendarAppSingleton } from '@schedule-x/shared/src'
 import { createCurrentTimePlugin } from '../../packages/current-time/src/current-time-plugin.impl.ts'
@@ -78,7 +82,7 @@ const calendar = createCalendar({
   // locale: 'id-ID',
   // locale: 'cs-CZ',
   locale: 'de-DE',
-  views: [viewMonthGrid, viewWeek, viewDay, viewMonthAgenda],
+  views: [viewMonthGrid, viewWeek, viewDay, viewMonthAgenda, viewYearAgenda],
   // defaultView: viewWeek.name,
   // minDate: '2024-01-01',
   // maxDate: '2024-03-31',

--- a/development/main.tsx
+++ b/development/main.tsx
@@ -8,26 +8,24 @@ import './app.css'
 import '../packages/theme-default/src/date-picker.scss'
 import { createDatePicker } from '../packages/date-picker/src'
 
-const datePicker = createDatePicker(
-  {
-    locale: 'de-DE',
-    style: {
-      fullWidth: true,
-    },
-    // locale: 'sv-SE',
-    firstDayOfWeek: 0,
-    selectedDate: '',
-    // selectedDate: '1991-07-13',
-    // placement: 'top-end',
-    // min: '2021-03-01',
-    // max: '2021-03-31',
-    // listeners: {
-    //   onChange: (value) => {
-    //     console.log('onChange', value)
-    //   },
-    // },
-  }
-)
+const datePicker = createDatePicker({
+  locale: 'de-DE',
+  style: {
+    fullWidth: true,
+  },
+  // locale: 'sv-SE',
+  firstDayOfWeek: 0,
+  selectedDate: '',
+  // selectedDate: '1991-07-13',
+  // placement: 'top-end',
+  // min: '2021-03-01',
+  // max: '2021-03-31',
+  // listeners: {
+  //   onChange: (value) => {
+  //     console.log('onChange', value)
+  //   },
+  // },
+})
 datePicker.render(document.querySelector('#app') as HTMLElement)
 
 // document.addEventListener('dblclick', () => {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:scss": "npx stylelint \"**/*.scss\"",
     "lint:scss:fix": "npx stylelint \"**/*.scss\" --fix --formatter compact",
     "clean:deps": "lerna clean",
-    "clean:build": "rm -rf ./packages/*/dist",
+    "clean:build": "",
     "release": "npm run build && lerna publish --conventional-commits --no-commit-hooks --force-publish --no-private",
     "release:pre": "npm run build && lerna publish --no-commit-hooks --conventional-commits --conventional-prerelease --force-publish",
     "release:bump:pre": "npm run build && lerna publish --no-commit-hooks --conventional-commits --conventional-bump-prerelease --force-publish",

--- a/packages/calendar/src/components/header/__test__/view-selection/utils.tsx
+++ b/packages/calendar/src/components/header/__test__/view-selection/utils.tsx
@@ -1,4 +1,5 @@
 import { createCalendarAppSingleton } from '../../../../factory'
+import { viewYearAgenda } from '../../../../views/year-agenda'
 import { viewDay } from '../../../../views/day'
 import { viewWeek } from '../../../../views/week'
 import { viewMonthGrid } from '../../../../views/month-grid'
@@ -9,7 +10,7 @@ import { viewMonthAgenda } from '../../../../views/month-agenda'
 
 export const renderComponent = () => {
   const $app = createCalendarAppSingleton({
-    views: [viewDay, viewWeek, viewMonthGrid, viewMonthAgenda],
+    views: [viewDay, viewWeek, viewMonthGrid, viewYearAgenda, viewMonthAgenda],
   })
 
   render(

--- a/packages/calendar/src/components/header/range-heading.tsx
+++ b/packages/calendar/src/components/header/range-heading.tsx
@@ -5,6 +5,7 @@ import { InternalViewName } from '@schedule-x/shared/src/enums/calendar/internal
 import {
   getMonthAndYearForSelectedDate,
   getMonthAndYearForDateRange,
+  getYearForSelectedDate,
 } from '../../utils/stateless/range-heading'
 
 export default function RangeHeading() {
@@ -29,6 +30,10 @@ export default function RangeHeading() {
       $app.calendarState.view.value === InternalViewName.MonthAgenda
     ) {
       setCurrentHeading(getMonthAndYearForSelectedDate($app))
+    }
+
+    if ($app.calendarState.view.value === InternalViewName.YearAgenda) {
+      setCurrentHeading(getYearForSelectedDate($app))
     }
   }, [$app.calendarState.range.value])
 

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -2,6 +2,7 @@ import { createCalendar } from './factory'
 import { viewWeek } from './views/week'
 import { viewMonthGrid } from './views/month-grid'
 import { viewDay } from './views/day'
+import { viewYearAgenda } from './views/year-agenda'
 import { viewMonthAgenda } from './views/month-agenda'
 import {
   CalendarConfigExternal as CalendarConfig,
@@ -25,6 +26,7 @@ export {
   viewMonthGrid,
   viewDay,
   viewMonthAgenda,
+  viewYearAgenda,
   CalendarApp,
   createPreactView,
   setRangeForDay,

--- a/packages/calendar/src/utils/stateless/range-heading.ts
+++ b/packages/calendar/src/utils/stateless/range-heading.ts
@@ -46,3 +46,11 @@ export const getMonthAndYearForSelectedDate = ($app: CalendarAppSingleton) => {
 
   return `${dateMonth} ${dateYear}`
 }
+
+export const getYearForSelectedDate = ($app: CalendarAppSingleton) => {
+  const dateYear = toJSDate(
+    $app.datePickerState.selectedDate.value
+  ).toLocaleString(...getLocaleStringYearArgs($app))
+
+  return dateYear
+}

--- a/packages/calendar/src/utils/stateless/time/range/set-range.ts
+++ b/packages/calendar/src/utils/stateless/time/range/set-range.ts
@@ -53,6 +53,14 @@ export const setRangeForWeek = (config: RangeSetterConfig): DateRange => {
   }
 }
 
+export const setRangeForYear = (config: RangeSetterConfig): DateRange => {
+  const { year } = toIntegers(config.date)
+  return {
+    start: toDateTimeString(new Date(year, 0, 1, 0, 0, 0, 0)),
+    end: toDateTimeString(new Date(year, 11, 31, 23, 59, 59, 999)),
+  }
+}
+
 export const setRangeForMonth = (config: RangeSetterConfig): DateRange => {
   const { year, month } = toIntegers(config.date)
   const monthForDate = config.timeUnitsImpl.getMonthWithTrailingAndLeadingDays(

--- a/packages/calendar/src/views/year-agenda/components/__test__/year-agenda-wrapper.spec.tsx
+++ b/packages/calendar/src/views/year-agenda/components/__test__/year-agenda-wrapper.spec.tsx
@@ -1,0 +1,45 @@
+import {
+  describe,
+  expect,
+  it,
+} from '@schedule-x/shared/src/utils/stateless/testing/unit/unit-testing-library.impl'
+import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
+import { cleanup, render } from '@testing-library/preact'
+import { __createAppWithViews__ } from '../../../../utils/stateless/testing/__create-app-with-views__'
+import { afterEach } from 'vitest'
+import { YearAgendaWrapper } from '../year-agenda-wrapper'
+
+const renderComponent = ($app: CalendarAppSingleton) => {
+  render(<YearAgendaWrapper $app={$app} id={'1'} />)
+}
+
+describe('YearAgendaWrapper', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  describe('rendering month for year', () => {
+    it('should render 12 month for 2023', () => {
+      const $app = __createAppWithViews__()
+      $app.datePickerState.selectedDate.value = '2023-10-01'
+      renderComponent($app)
+
+      expect(document.querySelectorAll('.sx__year-agenda-month').length).toBe(
+        12
+      )
+    })
+  })
+
+  describe('rendering the current month', () => {
+    it('should highlight the current date', () => {
+      renderComponent(__createAppWithViews__())
+      const monthNumber = new Date().getMonth()
+      const currentMonth = document.querySelectorAll('.sx__year-agenda-month')[
+        monthNumber
+      ]
+      expect(
+        currentMonth.querySelector('.sx__is-today')?.textContent
+      ).toBeTruthy()
+    })
+  })
+})

--- a/packages/calendar/src/views/year-agenda/components/year-agenda-event.tsx
+++ b/packages/calendar/src/views/year-agenda/components/year-agenda-event.tsx
@@ -1,0 +1,107 @@
+import { CalendarEventInternal } from '@schedule-x/shared/src/interfaces/calendar/calendar-event.interface'
+import { dateFromDateTime } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/string-to-string'
+import { AppContext } from '../../../utils/stateful/app-context'
+import { useContext, useEffect } from 'preact/hooks'
+import { getElementByCCID } from '../../../utils/stateless/dom/getters'
+import { randomStringId } from '@schedule-x/shared/src/utils/stateless/strings/random'
+import useEventInteractions from '../../../utils/stateful/hooks/use-event-interactions'
+import { invokeOnEventClickCallback } from '../../../utils/stateless/events/invoke-on-event-click-callback'
+import { isUIEventTouchEvent } from '@schedule-x/shared/src/utils/stateless/dom/is-touch-event'
+
+type props = {
+  gridRow: number
+  calendarEvent: CalendarEventInternal
+  date: string
+}
+
+export default function YearAgendaEvent({
+  gridRow,
+  calendarEvent,
+  date,
+}: props) {
+  const $app = useContext(AppContext)
+  const { createDragStartTimeout, setClickedEventIfNotDragging } =
+    useEventInteractions($app)
+
+  const hasStartDate = dateFromDateTime(calendarEvent.start) === date
+  const nDays = 1
+
+  const eventCSSVariables = {
+    borderLeft: hasStartDate
+      ? `4px solid var(--sx-color-${calendarEvent._color})`
+      : undefined,
+    color: `var(--sx-color-on-${calendarEvent._color}-container)`,
+    backgroundColor: `var(--sx-color-${calendarEvent._color}-container)`,
+    // CORRELATION ID: 2 (10px subtracted from width)
+    // nDays * 100% for the width of each day + 1px for border - 10 px for horizontal gap between events
+    width: `calc(${nDays * 100 + '%'} + ${nDays}px - 10px)`,
+  } as const
+
+  const handleStartDrag = (uiEvent: UIEvent) => {
+    if (isUIEventTouchEvent(uiEvent)) uiEvent.preventDefault()
+    if (!uiEvent.target) return
+    if (!$app.config.plugins.dragAndDrop || calendarEvent._options?.disableDND)
+      return
+
+    $app.config.plugins.dragAndDrop.createMonthGridDragHandler(
+      calendarEvent,
+      $app
+    )
+  }
+
+  const customComponent = $app.config._customComponentFns.monthGridEvent
+  const customComponentId = customComponent
+    ? 'custom-year-agenda-event-' + randomStringId() // needs a unique string to support event recurrence
+    : undefined
+
+  useEffect(() => {
+    if (!customComponent) return
+
+    customComponent(getElementByCCID(customComponentId), {
+      calendarEvent: calendarEvent._getExternalEvent(),
+      hasStartDate,
+    })
+  }, [calendarEvent])
+
+  const handleOnClick = (e: MouseEvent) => {
+    e.stopPropagation() // prevent the click from bubbling up to the day element
+    invokeOnEventClickCallback($app, calendarEvent)
+  }
+
+  const classNames = [
+    'sx__event',
+    'sx__year-agenda-event',
+    'sx__year-agenda-cell',
+  ]
+  if (calendarEvent._options?.additionalClasses) {
+    classNames.push(...calendarEvent._options.additionalClasses)
+  }
+
+  return (
+    <div
+      draggable={!!$app.config.plugins.dragAndDrop}
+      data-event-id={calendarEvent.id}
+      data-ccid={customComponentId}
+      onMouseDown={(e) => createDragStartTimeout(handleStartDrag, e)}
+      onMouseUp={(e) => setClickedEventIfNotDragging(calendarEvent, e)}
+      onTouchStart={(e) => createDragStartTimeout(handleStartDrag, e)}
+      onTouchEnd={(e) => setClickedEventIfNotDragging(calendarEvent, e)}
+      onClick={handleOnClick}
+      className={classNames.join(' ')}
+      style={{
+        gridRow,
+        width: eventCSSVariables.width,
+        padding: customComponent ? '0px' : undefined,
+        borderLeft: customComponent ? undefined : eventCSSVariables.borderLeft,
+        color: customComponent ? undefined : eventCSSVariables.color,
+        backgroundColor: customComponent
+          ? undefined
+          : eventCSSVariables.backgroundColor,
+      }}
+    >
+      {!customComponent && (
+        <div className="sx__year-agenda-event-title">{calendarEvent.title}</div>
+      )}
+    </div>
+  )
+}

--- a/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
+++ b/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
@@ -1,0 +1,104 @@
+import { toLocalizedMonth } from '@schedule-x/shared/src/utils/stateless/time/date-time-localization/date-time-localization'
+import { useContext } from 'preact/hooks'
+import { AppContext } from '../../../utils/stateful/app-context'
+import { InternalViewName } from '@schedule-x/shared/src/enums/calendar/internal-view.enum'
+import { DATE_GRID_BLOCKER } from '../../../constants'
+import { isSameMonth } from '@schedule-x/shared/src/utils/stateless/time/comparison'
+import { MonthAgenda as MonthAgendaType } from './../types/year-agenda'
+import YearAgendaEvent from './year-agenda-event'
+type props = {
+  month: MonthAgendaType
+}
+
+export default function YearAgendaMonth({ month }: props) {
+  const $app = useContext(AppContext)
+
+  const monthName = toLocalizedMonth(new Date(month.date), $app.config.locale)
+  let events = month.weeks.flatMap((week) => week.flatMap((day) => day.events))
+
+  events = events.filter(
+    (e, index) => events.findIndex((f) => f.id === e.id) === index
+  )
+
+  console.log('dove events ', events)
+
+  const nEventsInDay = events.filter(
+    (event) => typeof event === 'object' || event === DATE_GRID_BLOCKER
+  ).length
+
+  const getEventTranslationSingularOrPlural = (nOfAdditionalEvents: number) => {
+    if (nOfAdditionalEvents === 1) return $app.translate('event')
+    return $app.translate('events')
+  }
+
+  const handleClickAdditionalEvents = () => {
+    if ($app.config.callbacks.onClickPlusEvents)
+      $app.config.callbacks.onClickPlusEvents(month.date)
+    if (
+      !$app.config.views.find(
+        (view) => view.name === InternalViewName.MonthGrid
+      )
+    )
+      return
+
+    // Timeout to display the ripple effect
+    setTimeout(() => {
+      $app.datePickerState.selectedDate.value = month.date
+      $app.calendarState.view.value = InternalViewName.MonthGrid
+    }, 250)
+  }
+  const dateClassNames = ['sx__year-agenda-month__header-month-name']
+  if (isSameMonth(new Date(), new Date(month.date)))
+    dateClassNames.push('sx__is-today')
+
+  return (
+    <div
+      className="sx__year-agenda-month"
+      data-date={month.date}
+      onClick={() =>
+        $app.config.callbacks.onClickDate &&
+        $app.config.callbacks.onClickDate(month.date)
+      }
+      onDblClick={() => $app.config.callbacks.onDoubleClickDate?.(month.date)}
+    >
+      <div className="sx__year-agenda-month__header">
+        <div className={dateClassNames.join(' ')}>{monthName}</div>
+      </div>
+
+      <div className="sx__year-agenda-month__events">
+        {Object.values(events)
+          .slice(0, $app.config.monthGridOptions.nEventsPerDay)
+          .map((event, index) => {
+            if (typeof event !== 'object')
+              return (
+                <div
+                  className="sx__year-agenda-blocker sx__year-agenda-cell"
+                  style={{ gridRow: index + 1 }}
+                />
+              )
+
+            return (
+              <YearAgendaEvent
+                gridRow={index + 1}
+                calendarEvent={event}
+                date={month.date}
+              />
+            )
+          })}
+      </div>
+
+      {nEventsInDay > $app.config.monthGridOptions.nEventsPerDay ? (
+        <button
+          className="sx__year-agenda-month__events-more sx__ripple--wide"
+          onClick={handleClickAdditionalEvents}
+        >
+          {`+ ${
+            nEventsInDay - $app.config.monthGridOptions.nEventsPerDay
+          } ${getEventTranslationSingularOrPlural(
+            nEventsInDay - $app.config.monthGridOptions.nEventsPerDay
+          )}`}
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
+++ b/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
@@ -48,14 +48,9 @@ export default function YearAgendaMonth({ month }: props) {
   if (isSameMonth(new Date(), new Date(month.date)))
     dateClassNames.push('sx__is-today')
 
-  const containerClassNames = [
-    'sx__year-agenda-month',
-    $app.calendarState.isCalendarSmall.value ? 'isSmall' : null,
-  ]
-
   return (
     <div
-      className={containerClassNames.join(' ')}
+      className="sx__year-agenda-month"
       data-date={month.date}
       onClick={() =>
         $app.config.callbacks.onClickDate &&

--- a/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
+++ b/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
@@ -14,8 +14,7 @@ export default function YearAgendaMonth({ month }: props) {
   const $app = useContext(AppContext)
 
   const monthName = toLocalizedMonth(new Date(month.date), $app.config.locale)
-  let events = month.weeks.flatMap((week) => week.flatMap((day) => day.events))
-
+  let events = month.events
   events = events.filter(
     (e, index) => events.findIndex((f) => f.id === e.id) === index
   )

--- a/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
+++ b/packages/calendar/src/views/year-agenda/components/year-agenda-month.tsx
@@ -19,8 +19,6 @@ export default function YearAgendaMonth({ month }: props) {
     (e, index) => events.findIndex((f) => f.id === e.id) === index
   )
 
-  console.log('dove events ', events)
-
   const nEventsInDay = events.filter(
     (event) => typeof event === 'object' || event === DATE_GRID_BLOCKER
   ).length
@@ -50,9 +48,14 @@ export default function YearAgendaMonth({ month }: props) {
   if (isSameMonth(new Date(), new Date(month.date)))
     dateClassNames.push('sx__is-today')
 
+  const containerClassNames = [
+    'sx__year-agenda-month',
+    $app.calendarState.isCalendarSmall.value ? 'isSmall' : null,
+  ]
+
   return (
     <div
-      className="sx__year-agenda-month"
+      className={containerClassNames.join(' ')}
       data-date={month.date}
       onClick={() =>
         $app.config.callbacks.onClickDate &&

--- a/packages/calendar/src/views/year-agenda/components/year-agenda-wrapper.tsx
+++ b/packages/calendar/src/views/year-agenda/components/year-agenda-wrapper.tsx
@@ -1,0 +1,45 @@
+import { PreactViewComponent } from '@schedule-x/shared/src/types/calendar/preact-view-component'
+import { useEffect, useState } from 'preact/hooks'
+import YearAgendaMonth from './year-agenda-month'
+import { YearAgenda as YearAgendaType } from '../types/year-agenda'
+import { createAgendaYear } from '../utils/stateless/create-agenda-year'
+import { AppContext } from '../../../utils/stateful/app-context'
+import { positionEventsInYear } from '../utils/stateless/position-events-in-year'
+import { sortEventsByStartAndEnd } from '../../../utils/stateless/events/sort-by-start-date'
+
+export const YearAgendaWrapper: PreactViewComponent = ({ $app, id }) => {
+  const getYear = () => {
+    const filteredEvents = $app.calendarEvents.filterPredicate.value
+      ? $app.calendarEvents.list.value.filter(
+          $app.calendarEvents.filterPredicate.value
+        )
+      : $app.calendarEvents.list.value
+
+    return positionEventsInYear(
+      createAgendaYear($app.datePickerState.selectedDate.value),
+      filteredEvents.sort(sortEventsByStartAndEnd)
+    )
+  }
+
+  const [agendaYear, setAgendaYear] = useState<YearAgendaType>(getYear())
+
+  useEffect(() => {
+    setAgendaYear(getYear())
+  }, [
+    $app.datePickerState.selectedDate.value,
+    $app.calendarEvents.list.value,
+    $app.calendarEvents.filterPredicate.value,
+  ])
+
+  return (
+    <AppContext.Provider value={$app}>
+      <div id={id} className="sx__year-agenda-wrapper">
+        <div className="sx__year-agenda-container">
+          {agendaYear.map((month, index) => (
+            <YearAgendaMonth key={index} month={month} />
+          ))}
+        </div>
+      </div>
+    </AppContext.Provider>
+  )
+}

--- a/packages/calendar/src/views/year-agenda/index.ts
+++ b/packages/calendar/src/views/year-agenda/index.ts
@@ -1,0 +1,16 @@
+import { createPreactView } from '../../utils/stateful/preact-view/preact-view'
+import { InternalViewName } from '@schedule-x/shared/src/enums/calendar/internal-view.enum'
+import { addYears } from '@schedule-x/shared/src/utils/stateless/time/date-time-mutation/adding'
+import { setRangeForYear } from '../../utils/stateless/time/range/set-range'
+import { YearAgendaWrapper } from './components/year-agenda-wrapper'
+
+export const viewYearAgenda = createPreactView({
+  name: InternalViewName.YearAgenda,
+  label: 'Year',
+  setDateRange: setRangeForYear,
+  Component: YearAgendaWrapper,
+  hasSmallScreenCompat: true,
+  hasWideScreenCompat: true,
+  backwardForwardFn: addYears,
+  backwardForwardUnits: 1,
+})

--- a/packages/calendar/src/views/year-agenda/index.ts
+++ b/packages/calendar/src/views/year-agenda/index.ts
@@ -9,7 +9,7 @@ export const viewYearAgenda = createPreactView({
   label: 'Year',
   setDateRange: setRangeForYear,
   Component: YearAgendaWrapper,
-  hasSmallScreenCompat: true,
+  hasSmallScreenCompat: false,
   hasWideScreenCompat: true,
   backwardForwardFn: addYears,
   backwardForwardUnits: 1,

--- a/packages/calendar/src/views/year-agenda/types/year-agenda.ts
+++ b/packages/calendar/src/views/year-agenda/types/year-agenda.ts
@@ -1,0 +1,15 @@
+import { CalendarEventInternal } from '@schedule-x/shared/src/interfaces/calendar/calendar-event.interface'
+
+export type MonthAgendaDay = {
+  date: string
+  events: CalendarEventInternal[]
+}
+
+export type MonthAgendaWeek = MonthAgendaDay[]
+
+export type MonthAgenda = {
+  date: string
+  weeks: MonthAgendaWeek[]
+}
+
+export type YearAgenda = MonthAgenda[]

--- a/packages/calendar/src/views/year-agenda/types/year-agenda.ts
+++ b/packages/calendar/src/views/year-agenda/types/year-agenda.ts
@@ -1,15 +1,8 @@
 import { CalendarEventInternal } from '@schedule-x/shared/src/interfaces/calendar/calendar-event.interface'
 
-export type MonthAgendaDay = {
-  date: string
-  events: CalendarEventInternal[]
-}
-
-export type MonthAgendaWeek = MonthAgendaDay[]
-
 export type MonthAgenda = {
   date: string
-  weeks: MonthAgendaWeek[]
+  events: CalendarEventInternal[]
 }
 
 export type YearAgenda = MonthAgenda[]

--- a/packages/calendar/src/views/year-agenda/utils/stateless/__test__/position-events-in-year.spec.ts
+++ b/packages/calendar/src/views/year-agenda/utils/stateless/__test__/position-events-in-year.spec.ts
@@ -30,8 +30,8 @@ describe('Positioning events for in month view', () => {
 
     it('should position two events on first two levels of 1st of January', () => {
       const result = positionEventsInYear(month, sortedEvents)
-      expect(result[0].weeks[0][0].events[0]).toBe(event1)
-      expect(result[0].weeks[0][0].events[1]).toBe(event2)
+      expect(result[0].events[0]).toBe(event1)
+      expect(result[0].events[1]).toBe(event2)
     })
   })
 

--- a/packages/calendar/src/views/year-agenda/utils/stateless/__test__/position-events-in-year.spec.ts
+++ b/packages/calendar/src/views/year-agenda/utils/stateless/__test__/position-events-in-year.spec.ts
@@ -1,0 +1,39 @@
+/* eslint-disable max-lines */
+import {
+  describe,
+  it,
+  expect,
+} from '@schedule-x/shared/src/utils/stateless/testing/unit/unit-testing-library.impl'
+import { createAgendaYear } from '../create-agenda-year'
+import CalendarEventBuilder from '../../../../../../../shared/src/utils/stateless/calendar/calendar-event/calendar-event.builder'
+import { __createAppWithViews__ } from '../../../../../utils/stateless/testing/__create-app-with-views__'
+import { positionEventsInYear } from '../position-events-in-year'
+
+describe('Positioning events for in month view', () => {
+  const $app = __createAppWithViews__()
+
+  describe('Positioning single day events in first week', () => {
+    const month = createAgendaYear('2020-01-01')
+    const event1 = new CalendarEventBuilder(
+      $app.config,
+      1,
+      '2020-01-01',
+      '2020-01-01'
+    ).build()
+    const event2 = new CalendarEventBuilder(
+      $app.config,
+      1,
+      '2020-01-01',
+      '2020-01-01'
+    ).build()
+    const sortedEvents = [event1, event2]
+
+    it('should position two events on first two levels of 1st of January', () => {
+      const result = positionEventsInYear(month, sortedEvents)
+      expect(result[0].weeks[0][0].events[0]).toBe(event1)
+      expect(result[0].weeks[0][0].events[1]).toBe(event2)
+    })
+  })
+
+  // No multi days events in year overview mode
+})

--- a/packages/calendar/src/views/year-agenda/utils/stateless/create-agenda-year.ts
+++ b/packages/calendar/src/views/year-agenda/utils/stateless/create-agenda-year.ts
@@ -1,47 +1,15 @@
-import { MonthWithDates } from '@schedule-x/shared/src/types/time'
+import { toDateString } from '@schedule-x/shared/src'
+import { Month } from '@schedule-x/shared/src/enums/time/month.enum'
 import { YearAgenda as YearAgendaType } from '../../types/year-agenda'
 import { toIntegers } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
-import { toDateString } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/date-to-strings'
-
 export const createAgendaYear = (date: string): YearAgendaType => {
   const { year } = toIntegers(date)
-  const monthsWithDates = getAllWeeksOfYear(year)
-  return monthsWithDates.map((monthWithDates, month) => {
+  return Object.entries(Month).map((month, index) => {
     const date = new Date()
-    date.setFullYear(year, month, 1)
+    date.setFullYear(year, index, 1)
     return {
       date: toDateString(date),
-      weeks: monthWithDates.map((week) => {
-        return week.map((date) => {
-          return {
-            date: toDateString(date),
-            events: [],
-          }
-        })
-      }),
+      events: [],
     }
   })
-}
-
-function getWeeksOfMonth(year: number, month: number): MonthWithDates {
-  const weeks = []
-  const date = new Date(year, month, 1)
-  while (date.getMonth() === month) {
-    const week = []
-    for (let i = 0; i < 7; i++) {
-      week.push(new Date(date))
-      date.setDate(date.getDate() + 1)
-    }
-    weeks.push(week)
-  }
-  return weeks
-}
-
-function getAllWeeksOfYear(year: number): MonthWithDates[] {
-  const allWeeks = []
-  for (let month = 0; month < 12; month++) {
-    const weeks = getWeeksOfMonth(year, month)
-    allWeeks.push(weeks)
-  }
-  return allWeeks
 }

--- a/packages/calendar/src/views/year-agenda/utils/stateless/create-agenda-year.ts
+++ b/packages/calendar/src/views/year-agenda/utils/stateless/create-agenda-year.ts
@@ -1,10 +1,9 @@
 import { toDateString } from '@schedule-x/shared/src'
-import { Month } from '@schedule-x/shared/src/enums/time/month.enum'
 import { YearAgenda as YearAgendaType } from '../../types/year-agenda'
 import { toIntegers } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
 export const createAgendaYear = (date: string): YearAgendaType => {
   const { year } = toIntegers(date)
-  return Object.entries(Month).map((month, index) => {
+  return new Array(12).fill({}).map((data, index) => {
     const date = new Date()
     date.setFullYear(year, index, 1)
     return {

--- a/packages/calendar/src/views/year-agenda/utils/stateless/create-agenda-year.ts
+++ b/packages/calendar/src/views/year-agenda/utils/stateless/create-agenda-year.ts
@@ -1,0 +1,47 @@
+import { MonthWithDates } from '@schedule-x/shared/src/types/time'
+import { YearAgenda as YearAgendaType } from '../../types/year-agenda'
+import { toIntegers } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
+import { toDateString } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/date-to-strings'
+
+export const createAgendaYear = (date: string): YearAgendaType => {
+  const { year } = toIntegers(date)
+  const monthsWithDates = getAllWeeksOfYear(year)
+  return monthsWithDates.map((monthWithDates, month) => {
+    const date = new Date()
+    date.setFullYear(year, month, 1)
+    return {
+      date: toDateString(date),
+      weeks: monthWithDates.map((week) => {
+        return week.map((date) => {
+          return {
+            date: toDateString(date),
+            events: [],
+          }
+        })
+      }),
+    }
+  })
+}
+
+function getWeeksOfMonth(year: number, month: number): MonthWithDates {
+  const weeks = []
+  const date = new Date(year, month, 1)
+  while (date.getMonth() === month) {
+    const week = []
+    for (let i = 0; i < 7; i++) {
+      week.push(new Date(date))
+      date.setDate(date.getDate() + 1)
+    }
+    weeks.push(week)
+  }
+  return weeks
+}
+
+function getAllWeeksOfYear(year: number): MonthWithDates[] {
+  const allWeeks = []
+  for (let month = 0; month < 12; month++) {
+    const weeks = getWeeksOfMonth(year, month)
+    allWeeks.push(weeks)
+  }
+  return allWeeks
+}

--- a/packages/calendar/src/views/year-agenda/utils/stateless/position-events-in-year.ts
+++ b/packages/calendar/src/views/year-agenda/utils/stateless/position-events-in-year.ts
@@ -1,0 +1,52 @@
+import {
+  YearAgenda as YearAgendaType,
+  MonthAgendaDay as MonthAgendaDayType,
+} from '../../types/year-agenda'
+import { CalendarEventInternal } from '@schedule-x/shared/src/interfaces/calendar/calendar-event.interface'
+import { dateFromDateTime } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/string-to-string'
+import { addDays } from '@schedule-x/shared/src/utils/stateless/time/date-time-mutation/adding'
+
+const getAllEventDates = (startDate: string, endDate: string): string[] => {
+  let currentDate = startDate
+  const dates = [currentDate]
+
+  while (currentDate < endDate) {
+    currentDate = addDays(currentDate, 1)
+    dates.push(currentDate)
+  }
+
+  return dates
+}
+
+const placeEventInDay =
+  (allDaysMap: Record<string, MonthAgendaDayType>) =>
+  (event: CalendarEventInternal) => {
+    getAllEventDates(
+      dateFromDateTime(event.start),
+      dateFromDateTime(event.end)
+    ).forEach((date) => {
+      if (allDaysMap[date]) {
+        allDaysMap[date].events.push(event)
+      }
+    })
+  }
+
+export const positionEventsInYear = (
+  agendaYear: YearAgendaType,
+  eventsSortedByStart: CalendarEventInternal[]
+) => {
+  return agendaYear.map((agendaMonth) => {
+    const allDaysMap = agendaMonth.weeks.reduce(
+      (acc, week) => {
+        week.forEach((day) => {
+          acc[day.date] = day
+        })
+        return acc
+      },
+      {} as Record<string, MonthAgendaDayType>
+    )
+
+    eventsSortedByStart.forEach(placeEventInDay(allDaysMap))
+    return agendaMonth
+  })
+}

--- a/packages/shared/src/enums/calendar/internal-view.enum.ts
+++ b/packages/shared/src/enums/calendar/internal-view.enum.ts
@@ -4,4 +4,5 @@ export enum InternalViewName {
   Week = 'week',
   MonthGrid = 'month-grid',
   MonthAgenda = 'month-agenda',
+  YearAgenda = 'year-agenda',
 }

--- a/packages/theme-default/src/calendar.scss
+++ b/packages/theme-default/src/calendar.scss
@@ -15,6 +15,7 @@
 @import 'components/calendar/header/view-selection';
 @import 'components/calendar/view-month-grid';
 @import 'components/calendar/view-month-agenda';
+@import 'components/calendar/view-year-agenda';
 @import 'components/calendar/view-week';
 @import 'components/calendar/week-grid';
 @import 'components/calendar/event-modal';

--- a/packages/theme-default/src/components/calendar/view-year-agenda/index.scss
+++ b/packages/theme-default/src/components/calendar/view-year-agenda/index.scss
@@ -1,0 +1,3 @@
+@import 'year-agenda-wrapper';
+@import 'year-agenda-month';
+@import 'year-agenda-month-events';

--- a/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month-events.scss
+++ b/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month-events.scss
@@ -1,0 +1,23 @@
+.sx__year-agenda-month__events {
+  display: grid;
+  grid-gap: 4px;
+}
+
+.sx__year-agenda-cell {
+  height: clamp(20px, 1.25rem, 24px);
+}
+
+.sx__year-agenda-event {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: var(--sx-spacing-padding1);
+  border-radius: var(--sx-rounding-extra-small);
+  font-size: clamp(12px, var(--sx-font-extra-small), 14px);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.sx__year-agenda-blocker {
+  pointer-events: none;
+}

--- a/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month.scss
+++ b/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month.scss
@@ -1,23 +1,21 @@
 .sx__year-agenda-container {
-  border-top: var(--sx-border);
   flex: 1;
   display: flex;
   flex-flow: row wrap;
 }
 
-// Flex options
-// 15% > 6 cols x 2 rows
-// 25% > 4x3
-// 30% > 3x4
-
 .sx__year-agenda-month {
   padding: var(--sx-spacing-padding2) 0;
-  flex: 1 25%;
-  min-width: 300px;
-  border-bottom: var(--sx-border);
+  width: calc(100% / 4);
+  border-top: var(--sx-border);
 
-  &:not(:last-child) {
+  &:not(:nth-child(4n)) {
     border-right: var(--sx-border);
+  }
+
+  &.isSmall {
+    width: 100%;
+    border-right: none !important;
   }
 }
 

--- a/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month.scss
+++ b/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month.scss
@@ -1,0 +1,86 @@
+.sx__year-agenda-container {
+  border-top: var(--sx-border);
+  flex: 1;
+  display: flex;
+  flex-flow: row wrap;
+}
+
+// Flex options
+// 15% > 6 cols x 2 rows
+// 25% > 4x3
+// 30% > 3x4
+
+.sx__year-agenda-month {
+  padding: var(--sx-spacing-padding2) 0;
+  flex: 1 25%;
+  min-width: 300px;
+  border-bottom: var(--sx-border);
+
+  &:not(:last-child) {
+    border-right: var(--sx-border);
+  }
+}
+
+.sx__year-agenda-month--dragover {
+  background-color: var(--sx-color-surface-container);
+}
+
+.sx__year-agenda-month__header {
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+}
+
+.sx__year-agenda-month__header-day-name {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--sx-color-neutral);
+}
+
+.sx__year-agenda-month__header-month-name {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--sx-color-neutral);
+  padding: 4px;
+  margin: 0 0 8px;
+
+  &.sx__is-today {
+    background-color: var(--sx-color-primary);
+    color: var(--sx-color-on-primary);
+    border-radius: 4px;
+  }
+}
+
+.sx__year-agenda-month__header-date {
+  font-size: var(--sx-font-extra-small);
+  margin-bottom: var(--sx-spacing-padding1);
+  border-radius: 50%;
+  height: 24px;
+  width: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &.sx__is-today {
+    background-color: var(--sx-color-primary);
+    color: var(--sx-color-on-primary);
+  }
+}
+
+.sx__year-agenda-month__events-more {
+  width: calc(100% - 10px); // CORRELATION ID: 2 (10px subtracted from width)
+  font-size: var(--sx-font-extra-small);
+  color: var(--sx-color-neutral);
+  margin: var(--sx-spacing-padding1) 0;
+  padding: var(--sx-spacing-padding1);
+  border-radius: var(--sx-rounding-extra-small);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease-in-out,
+    color 0.2s ease-in-out;
+
+  &:hover {
+    background-color: var(--sx-color-surface-container);
+    color: var(--sx-color-on-surface);
+  }
+}

--- a/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month.scss
+++ b/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-month.scss
@@ -7,16 +7,13 @@
 .sx__year-agenda-month {
   padding: var(--sx-spacing-padding2) 0;
   width: calc(100% / 4);
+  height: calc(100% / 3);
   border-top: var(--sx-border);
 
   &:not(:nth-child(4n)) {
     border-right: var(--sx-border);
   }
 
-  &.isSmall {
-    width: 100%;
-    border-right: none !important;
-  }
 }
 
 .sx__year-agenda-month--dragover {

--- a/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-wrapper.scss
+++ b/packages/theme-default/src/components/calendar/view-year-agenda/year-agenda-wrapper.scss
@@ -1,0 +1,5 @@
+.sx__year-agenda-wrapper {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}

--- a/packages/translations/src/locales/cs-CZ/calendar.ts
+++ b/packages/translations/src/locales/cs-CZ/calendar.ts
@@ -2,8 +2,8 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarCsCZ: CalendarTranslations = {
   Today: 'Dnes',
-  Month: 'Měsíc',
   Year: 'Rok',
+  Month: 'Měsíc',
   Week: 'Týden',
   Day: 'Den',
   events: 'události',

--- a/packages/translations/src/locales/cs-CZ/calendar.ts
+++ b/packages/translations/src/locales/cs-CZ/calendar.ts
@@ -3,6 +3,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 export const calendarCsCZ: CalendarTranslations = {
   Today: 'Dnes',
   Month: 'Měsíc',
+  Year: 'Rok',
   Week: 'Týden',
   Day: 'Den',
   events: 'události',

--- a/packages/translations/src/locales/da-DK/calendar.ts
+++ b/packages/translations/src/locales/da-DK/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarDaDK: CalendarTranslations = {
   Today: 'I dag',
+  Year: 'År',
   Month: 'Måned',
   Week: 'Uge',
   Day: 'Dag',

--- a/packages/translations/src/locales/de-DE/calendar.ts
+++ b/packages/translations/src/locales/de-DE/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarDeDE: CalendarTranslations = {
   Today: 'Heute',
+  Year: 'Jahr',
   Month: 'Monat',
   Week: 'Woche',
   Day: 'Tag',

--- a/packages/translations/src/locales/en-GB/calendar.ts
+++ b/packages/translations/src/locales/en-GB/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarEnGB: CalendarTranslations = {
   Today: 'Today',
+  Year: 'Year',
   Month: 'Month',
   Week: 'Week',
   Day: 'Day',

--- a/packages/translations/src/locales/en-US/calendar.ts
+++ b/packages/translations/src/locales/en-US/calendar.ts
@@ -3,6 +3,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 export const calendarEnUS: CalendarTranslations = {
   Today: 'Today',
   Month: 'Month',
+  Year: 'Year',
   Week: 'Week',
   Day: 'Day',
   events: 'events',

--- a/packages/translations/src/locales/en-US/calendar.ts
+++ b/packages/translations/src/locales/en-US/calendar.ts
@@ -2,8 +2,8 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarEnUS: CalendarTranslations = {
   Today: 'Today',
-  Month: 'Month',
   Year: 'Year',
+  Month: 'Month',
   Week: 'Week',
   Day: 'Day',
   events: 'events',

--- a/packages/translations/src/locales/es-ES/calendar.ts
+++ b/packages/translations/src/locales/es-ES/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarEsES: CalendarTranslations = {
   Today: 'Hoy',
+  Year: 'Año',
   Month: 'Mes',
   Week: 'Semana',
   Day: 'Día',

--- a/packages/translations/src/locales/fr-FR/calendar.ts
+++ b/packages/translations/src/locales/fr-FR/calendar.ts
@@ -2,8 +2,8 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarFrFR: CalendarTranslations = {
   Today: "Aujourd'hui",
-  Month: 'Mois',
   Year: 'Année',
+  Month: 'Mois',
   Week: 'Semaine',
   Day: 'Jour',
   events: 'événements',

--- a/packages/translations/src/locales/fr-FR/calendar.ts
+++ b/packages/translations/src/locales/fr-FR/calendar.ts
@@ -3,6 +3,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 export const calendarFrFR: CalendarTranslations = {
   Today: "Aujourd'hui",
   Month: 'Mois',
+  Year: 'Année',
   Week: 'Semaine',
   Day: 'Jour',
   events: 'événements',

--- a/packages/translations/src/locales/id-ID/calendar.ts
+++ b/packages/translations/src/locales/id-ID/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarIdID: CalendarTranslations = {
   Today: 'Hari Ini',
+  Year: 'Tahun',
   Month: 'Bulan',
   Week: 'Minggu',
   Day: 'Hari',

--- a/packages/translations/src/locales/it-IT/calendar.ts
+++ b/packages/translations/src/locales/it-IT/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarItIT: CalendarTranslations = {
   Today: 'Oggi',
+  Year: 'Anno',
   Month: 'Mese',
   Week: 'Settimana',
   Day: 'Giorno',

--- a/packages/translations/src/locales/ja-JP/calendar.ts
+++ b/packages/translations/src/locales/ja-JP/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarJaJP: CalendarTranslations = {
   Today: '今日',
+  Year: '年',
   Month: '月',
   Week: '週',
   Day: '日',

--- a/packages/translations/src/locales/ko-KR/calender.ts
+++ b/packages/translations/src/locales/ko-KR/calender.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarKoKR: CalendarTranslations = {
   Today: '오늘',
+  Year: '년',
   Month: '월',
   Week: '주',
   Day: '일',

--- a/packages/translations/src/locales/ky-KG/calendar.ts
+++ b/packages/translations/src/locales/ky-KG/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarKyKG: CalendarTranslations = {
   Today: 'Бүгүн',
+  Year: 'Жыл',
   Month: 'Ай',
   Week: 'Апта',
   Day: 'Күн',

--- a/packages/translations/src/locales/mk-MK/calendar.ts
+++ b/packages/translations/src/locales/mk-MK/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarMkMK: CalendarTranslations = {
   Today: 'Денес',
+  Year: 'Година',
   Month: 'Месец',
   Week: 'Недела',
   Day: 'Ден',

--- a/packages/translations/src/locales/nl-NL/calendar.ts
+++ b/packages/translations/src/locales/nl-NL/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarNlNL: CalendarTranslations = {
   Today: 'Vandaag',
+  Year: 'Jaar',
   Month: 'Maand',
   Week: 'Week',
   Day: 'Dag',

--- a/packages/translations/src/locales/pl-PL/calendar.ts
+++ b/packages/translations/src/locales/pl-PL/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarPlPL: CalendarTranslations = {
   Today: 'Dzisiaj',
+  Year: 'Rok',
   Month: 'Miesiąc',
   Week: 'Tydzień',
   Day: 'Dzień',

--- a/packages/translations/src/locales/pt-BR/calendar.ts
+++ b/packages/translations/src/locales/pt-BR/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarPtBR: CalendarTranslations = {
   Today: 'Hoje',
+  Year: 'Ano',
   Month: 'Mês',
   Week: 'Semana',
   Day: 'Dia',

--- a/packages/translations/src/locales/ru-RU/calendar.ts
+++ b/packages/translations/src/locales/ru-RU/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarRuRU: CalendarTranslations = {
   Today: 'Сегодня',
+  Year: 'Год',
   Month: 'Месяц',
   Week: 'Неделя',
   Day: 'День',

--- a/packages/translations/src/locales/sk-SK/calendar.ts
+++ b/packages/translations/src/locales/sk-SK/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarSkSK: CalendarTranslations = {
   Today: 'Dnes',
+  Year: 'Rok',
   Month: 'Mesiac',
   Week: 'Týždeň',
   Day: 'Deň',

--- a/packages/translations/src/locales/sv-SE/calendar.ts
+++ b/packages/translations/src/locales/sv-SE/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarSvSE: CalendarTranslations = {
   Today: 'Idag',
+  Year: 'År',
   Month: 'Månad',
   Week: 'Vecka',
   Day: 'Dag',

--- a/packages/translations/src/locales/tr-TR/calendar.ts
+++ b/packages/translations/src/locales/tr-TR/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarTrTR: CalendarTranslations = {
   Today: 'Bugün',
+  Year: 'Yıl',
   Month: 'Aylık',
   Week: 'Haftalık',
   Day: 'Günlük',

--- a/packages/translations/src/locales/zh-CN/calendar.ts
+++ b/packages/translations/src/locales/zh-CN/calendar.ts
@@ -2,6 +2,7 @@ import { CalendarTranslations } from '../../types/calendar.translations'
 
 export const calendarZhCN: CalendarTranslations = {
   Today: '今天',
+  Year: '年',
   Month: '月',
   Week: '周',
   Day: '日',

--- a/packages/translations/src/types/calendar.translations.ts
+++ b/packages/translations/src/types/calendar.translations.ts
@@ -1,6 +1,7 @@
 export interface CalendarTranslations {
   Today: string
   Month: string
+  Year: string
   Week: string
   Day: string
   events: string

--- a/website/components/partials/app-calendar/app-calendar.tsx
+++ b/website/components/partials/app-calendar/app-calendar.tsx
@@ -1,14 +1,23 @@
 import '@schedule-x/theme-default/dist/index.css'
-import { viewDay, viewMonthAgenda, viewMonthGrid, viewWeek } from '@schedule-x/calendar'
+import {
+  viewDay,
+  viewMonthAgenda,
+  viewMonthGrid,
+  viewWeek,
+} from '@schedule-x/calendar'
 import { seededEvents } from './data/seeded-events'
 import { useEffect } from 'react'
 import { useTheme } from 'nextra-theme-docs'
 import { createDragAndDropPlugin } from '@schedule-x/drag-and-drop'
 import { createEventModalPlugin } from '@schedule-x/event-modal'
-import { ScheduleXCalendar, useNextCalendarApp } from '@schedule-x/react/dist/index'
+import {
+  ScheduleXCalendar,
+  useNextCalendarApp,
+} from '@schedule-x/react/dist/index'
 import { createResizePlugin } from '@schedule-x/resize'
 
-const getTheme = (resolvedTheme: string) => resolvedTheme === 'dark' ? 'dark' : 'light'
+const getTheme = (resolvedTheme: string) =>
+  resolvedTheme === 'dark' ? 'dark' : 'light'
 
 export default function AppCalendar() {
   const { resolvedTheme } = useTheme()
@@ -17,7 +26,11 @@ export default function AppCalendar() {
     views: [viewWeek, viewMonthAgenda, viewDay, viewMonthGrid],
     defaultView: viewWeek.name,
     events: seededEvents,
-    plugins: [createDragAndDropPlugin(), createEventModalPlugin(), createResizePlugin()],
+    plugins: [
+      createDragAndDropPlugin(),
+      createEventModalPlugin(),
+      createResizePlugin(),
+    ],
     selectedDate: '2024-01-13',
     isDark: getTheme(resolvedTheme) === 'dark',
     calendars: {
@@ -73,7 +86,7 @@ export default function AppCalendar() {
           container: '#426aa2',
         },
       },
-    }
+    },
   })
 
   useEffect(() => {
@@ -82,7 +95,9 @@ export default function AppCalendar() {
     }
   }, [resolvedTheme])
 
-  return <>
-    <ScheduleXCalendar calendarApp={calendarApp} />
-  </>
+  return (
+    <>
+      <ScheduleXCalendar calendarApp={calendarApp} />
+    </>
+  )
 }

--- a/website/pages/docs/calendar/views.mdx
+++ b/website/pages/docs/calendar/views.mdx
@@ -23,7 +23,7 @@ large screens.
 ## The available views
 
 | View name    | Large screens | Small screens |
-|--------------|---------------|---------------|
+| ------------ | ------------- | ------------- |
 | Day          | Yes           | Yes           |
 | Month grid   | Yes           | No            |
 | Month agenda | No            | Yes           |
@@ -38,6 +38,7 @@ import {
   viewMonthAgenda,
   viewMonthGrid,
   viewWeek,
+  MonthAgendaDay
 } from '@schedule-x/calendar'
 import '@schedule-x/theme-default/dist/index.css'
 

--- a/website/pages/docs/calendar/vue.mdx
+++ b/website/pages/docs/calendar/vue.mdx
@@ -33,6 +33,7 @@ import {
   viewWeek,
   viewMonthGrid,
   viewMonthAgenda,
+  viewYearAgenda
 } from '@schedule-x/calendar'
 import '@schedule-x/theme-default/dist/index.css'
 
@@ -102,7 +103,7 @@ The Schedule-X calendar is built with customization in mind. Using Vue slots or 
 control over the rendering in parts of the UI. Currently, these components can be customized:
 
 | Slot / Component name | Description                                                      | Props                           |
-|-----------------------|------------------------------------------------------------------|---------------------------------|
+| --------------------- | ---------------------------------------------------------------- | ------------------------------- |
 | `timeGridEvent`       | The component for timed events used in the week- and day views   | `calendarEvent`                 |
 | `dateGridEvent`       | The component for all-day events used in the week- and day views | `calendarEvent`                 |
 | `monthGridEvent`      | The component for events used in the month grid view             | `calendarEvent`, `hasStartDate` |


### PR DESCRIPTION
Hello team,

🎉 This is my first contribution to the project (schedule-x). I’ve opened a PR to introduce a new annual view for the calendar.

This new view provides a comprehensive overview of all planned events throughout the year. By clicking the "see more events" button, the calendar will automatically switch to the monthly view.

 Currently, I haven't figured out how to manage recurrence or enable drag-and-drop for events in this mode yet.

 I'd love to hear your thoughts on this addition and any suggestions you might have. Do you think this feature could be integrated into the project?

Thank you for your consideration!

Best regards,
Dove

![image](https://github.com/schedule-x/schedule-x/assets/33008055/209a9058-2631-4fcb-8eea-d8e78a7634ff)



