### PR TITLE
fix: set names for globals in umd bundle

### DIFF
--- a/packages/calendar-controls/package.json
+++ b/packages/calendar-controls/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/calendar-controls",
+  "umdName": "SXCalendarControls",
   "version": "1.58.1",
   "description": "Plugin for extra controls for the Schedule-X calendar",
   "author": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/calendar",
+  "umdName": "ScheduleXCalendar",
   "version": "1.58.1",
   "description": "Schedule-X calendar component",
   "author": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schedule-x/calendar",
-  "umdName": "ScheduleXCalendar",
+  "umdName": "SXCalendar",
   "version": "1.58.1",
   "description": "Schedule-X calendar component",
   "author": {

--- a/packages/current-time/package.json
+++ b/packages/current-time/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/current-time",
+  "umdName": "SXCurrentTime",
   "version": "1.58.1",
   "description": "Schedule-X plugin for displaying an indicator for the current time",
   "author": {

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/date-picker",
+  "umdName": "SXDatePicker",
   "version": "1.58.1",
   "description": "Schedule-X date picker component",
   "author": {

--- a/packages/drag-and-drop/package.json
+++ b/packages/drag-and-drop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/drag-and-drop",
+  "umdName": "SXDragAndDrop",
   "version": "1.58.1",
   "description": "Drag & drop plugin for Schedule-X calendar",
   "author": {

--- a/packages/event-modal/package.json
+++ b/packages/event-modal/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/event-modal",
+  "umdName": "SXEventModal",
   "version": "1.58.1",
   "description": "Plugin for Schedule-X to show a modal when clicking on an event",
   "author": {

--- a/packages/event-recurrence/package.json
+++ b/packages/event-recurrence/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/event-recurrence",
+  "umdName": "SXEventRecurrence",
   "version": "1.58.1",
   "description": "Create recurring events for the Schedule-X calendar",
   "author": {

--- a/packages/events-service/package.json
+++ b/packages/events-service/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/events-service",
+  "umdName": "SXEventsService",
   "version": "1.58.1",
   "publishConfig": {
     "access": "public"

--- a/packages/recurrence/package.json
+++ b/packages/recurrence/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/recurrence",
+  "umdName": "SXRecurrence",
   "version": "1.58.1",
   "description": "A library for working with recurring events according to the iCalendar specification",
   "author": {

--- a/packages/resize/package.json
+++ b/packages/resize/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/resize",
+  "umdName": "SXResize",
   "version": "1.58.1",
   "description": "Resize events in the Schedule-X calendar",
   "author": {

--- a/packages/scroll-controller/package.json
+++ b/packages/scroll-controller/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/scroll-controller",
+  "umdName": "SXScrollController",
   "version": "1.58.1",
   "description": "Schedule-X calendar scroll controller",
   "author": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/shared",
+  "umdName": "SXShared",
   "version": "1.58.1",
   "publishConfig": {
     "access": "public"

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/time-picker",
+  "umdName": "SXTimePicker",
   "version": "1.58.1",
   "description": "Schedule-X time picker component",
   "author": {

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@schedule-x/translations",
+  "umdName": "SXTranslations",
   "version": "1.58.1",
   "description": "Schedule-X translations",
   "author": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,7 @@ async function build(commandLineArgs) {
   packages.forEach((pkg) => {
     const basePath = path.relative(__dirname, pkg.location)
     const input = path.join(basePath, 'src/index.ts')
-    const { name, main, umd, module } = pkg.toJSON()
+    const { name, main, umd, module, umdName } = pkg.toJSON()
 
     const basePlugins = [
       resolve(),
@@ -57,9 +57,16 @@ async function build(commandLineArgs) {
       input,
       output: [
         {
-          name,
+          name: umdName || name,
           file: path.join(basePath, umd),
           format: 'umd',
+          globals: {
+            preact: 'preact',
+            '@preact/signals': 'preactSignals',
+            '@preact/signals-core': 'preactSignalsCore',
+            'preact/hooks': 'preactHooks',
+            'preact/compat': 'preactCompat',
+          }
         },
         {
           name,


### PR DESCRIPTION
## This PR solves the following problem**. 

In [#429](https://github.com/schedule-x/schedule-x/issues/429) it was reported that the library can't be used over CDN out of the box. This PR should fix this.