### PR TITLE
Add an option for hour labels format on the time axis

### DIFF
--- a/packages/calendar/src/components/week-grid/__test__/time-axis.spec.tsx
+++ b/packages/calendar/src/components/week-grid/__test__/time-axis.spec.tsx
@@ -1,0 +1,68 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+} from '@schedule-x/shared/src/utils/stateless/testing/unit/unit-testing-library.impl'
+import { cleanup, render, screen } from '@testing-library/preact'
+import TimeAxis from '../time-axis'
+import { AppContext } from '../../../utils/stateful/app-context'
+import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
+import { __createAppWithViews__ } from '../../../utils/stateless/testing/__create-app-with-views__'
+
+const renderComponent = ($app: CalendarAppSingleton) => {
+  render(
+    <AppContext.Provider value={$app}>
+      <TimeAxis />
+    </AppContext.Provider>
+  )
+}
+
+describe('TimeAxis', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  describe('displaying default time axis', () => {
+    it('should display all hours in en-US locale', () => {
+      renderComponent(__createAppWithViews__())
+      for (const ampm of ['AM', 'PM']) {
+        for (let hour = 1; hour <= 12; ++hour) {
+          expect(screen.getByText(`${hour} ${ampm}`)).not.toBeNull()
+        }
+      }
+    })
+  })
+
+  describe('displaying time axis in de-DE', () => {
+    it('should display all hours as "xx Uhr"', () => {
+      renderComponent(__createAppWithViews__({ locale: 'de-DE' }))
+      for (let hour = 0; hour < 24; ++hour) {
+        expect(
+          screen.getByText(hour.toString().padStart(2, '0') + ' Uhr')
+        ).not.toBeNull()
+      }
+    })
+  })
+
+  describe('displaying time axis with custom timeAxisFormatOptions', () => {
+    it('should display all hours as xx:00', () => {
+      renderComponent(
+        __createAppWithViews__({
+          weekOptions: {
+            timeAxisFormatOptions: {
+              hour12: false,
+              hour: '2-digit',
+              minute: '2-digit',
+            },
+          },
+        })
+      )
+      for (let hour = 0; hour < 24; ++hour) {
+        expect(
+          screen.getByText(hour.toString().padStart(2, '0') + ':00')
+        ).not.toBeNull()
+      }
+    })
+  })
+})

--- a/packages/calendar/src/components/week-grid/__test__/time-axis.spec.tsx
+++ b/packages/calendar/src/components/week-grid/__test__/time-axis.spec.tsx
@@ -49,6 +49,10 @@ describe('TimeAxis', () => {
     it('should display all hours as xx:00', () => {
       renderComponent(
         __createAppWithViews__({
+          dayBoundaries: {
+            start: '01:00',
+            end: '23:59',
+          },
           weekOptions: {
             timeAxisFormatOptions: {
               hour12: false,
@@ -58,7 +62,7 @@ describe('TimeAxis', () => {
           },
         })
       )
-      for (let hour = 0; hour < 24; ++hour) {
+      for (let hour = 1; hour < 24; ++hour) {
         expect(
           screen.getByText(hour.toString().padStart(2, '0') + ':00')
         ).not.toBeNull()

--- a/packages/calendar/src/components/week-grid/time-axis.tsx
+++ b/packages/calendar/src/components/week-grid/time-axis.tsx
@@ -18,15 +18,18 @@ export default function TimeAxis() {
     )
   }, [])
 
+  const formatter = new Intl.DateTimeFormat(
+    $app.config.locale,
+    $app.config.weekOptions.timeAxisFormatOptions
+  )
+
   return (
     <>
       <div className="sx__week-grid__time-axis">
         {hours.map((hour) => (
           <div className="sx__week-grid__hour">
             <span className="sx__week-grid__hour-text">
-              {new Date(0, 0, 0, hour).toLocaleTimeString($app.config.locale, {
-                hour: 'numeric',
-              })}
+              {formatter.format(new Date(0, 0, 0, hour))}
             </span>
           </div>
         ))}

--- a/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
@@ -31,6 +31,7 @@ export default class CalendarConfigBuilder
     gridHeight: DEFAULT_WEEK_GRID_HEIGHT,
     nDays: 7,
     eventWidth: 100,
+    timeAxisFormatOptions: { hour: 'numeric' },
   }
   monthGridOptions: MonthGridOptions | undefined
   calendars: Record<string, CalendarType> | undefined

--- a/packages/shared/src/interfaces/calendar/calendar-config.ts
+++ b/packages/shared/src/interfaces/calendar/calendar-config.ts
@@ -20,6 +20,7 @@ export type WeekOptions = {
   gridHeight: number
   nDays: number
   eventWidth: number
+  timeAxisFormatOptions: Intl.DateTimeFormatOptions
 }
 
 export type MonthGridOptions = {

--- a/website/pages/docs/calendar/configuration.mdx
+++ b/website/pages/docs/calendar/configuration.mdx
@@ -84,6 +84,12 @@ const config = {
     * Defaults to 100, but can be used to leave a small margin to the right of the event
     */
     eventWidth: 95,
+
+    /**
+    * Intl.DateTimeFormatOptions used to format the hour labels on the time axis
+    * Default: { hour: 'numeric' }
+    */
+    timeAxisFormatOptions: { hour: '2-digit', minute: '2-digit' },
   },
 
   monthGridOptions: {


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [x] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

Happy to write a test for this, haven't looked into it yet.

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

See #621.

## How to test this PR**. 

For example:  
1. Specify `timeAxisFormatOptions: { hour: '2-digit', minute: '2-digit' }` in `weekOptions` in the calendar config.
2. Now the hour labels look like: `08:00` if the locale is `de-DE`.