### PR TITLE
feat: add a config option to show location in week/day view (#348)

### DIFF
--- a/packages/calendar/src/components/week-grid/__test__/time-grid-event/time-grid-event.spec.tsx
+++ b/packages/calendar/src/components/week-grid/__test__/time-grid-event/time-grid-event.spec.tsx
@@ -65,5 +65,48 @@ describe('TimeGridEvent', () => {
       const anotherClass = document.querySelector('.another-class')
       expect(anotherClass).not.toBeNull()
     })
+
+    it('should not show the location by default', () => {
+      const $app = __createAppWithViews__({
+        events: [
+          {
+            id: '123',
+            title: 'Event 1',
+            start: '2020-01-01 00:00',
+            end: '2020-01-02 01:00',
+            location: 'Location 1',
+          },
+        ],
+      })
+      renderComponent($app, $app.calendarEvents.list.value[0])
+
+      const timeGridEvent = document.querySelector(
+        '.sx__time-grid-event-location'
+      )
+      expect(timeGridEvent).toBeNull()
+    })
+
+    it('should show the location if showLocation is true', () => {
+      const $app = __createAppWithViews__({
+        weekOptions: {
+          showLocation: true,
+        },
+        events: [
+          {
+            id: '123',
+            title: 'Event 1',
+            start: '2020-01-01 00:00',
+            end: '2020-01-02 01:00',
+            location: 'Location 1',
+          },
+        ],
+      })
+      renderComponent($app, $app.calendarEvents.list.value[0])
+
+      const timeGridEvent = document.querySelector(
+        '.sx__time-grid-event-location'
+      )
+      expect(timeGridEvent).not.toBeNull()
+    })
   })
 })

--- a/packages/calendar/src/components/week-grid/time-grid-event.tsx
+++ b/packages/calendar/src/components/week-grid/time-grid-event.tsx
@@ -11,6 +11,7 @@ import { AppContext } from '../../utils/stateful/app-context'
 import { toJSDate } from '@schedule-x/shared/src/utils/stateless/time/format-conversion/format-conversion'
 import UserIcon from '@schedule-x/shared/src/components/icons/user-icon'
 import TimeIcon from '@schedule-x/shared/src/components/icons/time-icon'
+import LocationPinIcon from '@schedule-x/shared/src/components/icons/location-pin-icon'
 import { deepCloneEvent } from '@schedule-x/shared/src/utils/stateless/calendar/deep-clone-event'
 import { DayBoundariesDateTime } from '@schedule-x/shared/src/types/day-boundaries-date-time'
 import { getTimeGridEventCopyElementId } from '@schedule-x/shared/src/utils/stateless/strings/selector-generators'
@@ -207,6 +208,16 @@ export default function TimeGridEvent({
                   {concatenatePeople(calendarEvent.people)}
                 </div>
               )}
+
+              {calendarEvent.location &&
+                $app.config.weekOptions.showLocation && (
+                  <div className="sx__time-grid-event-location">
+                    <LocationPinIcon
+                      strokeColor={eventCSSVariables.iconStroke}
+                    />
+                    {calendarEvent.location}
+                  </div>
+                )}
             </Fragment>
           )}
 

--- a/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
@@ -32,6 +32,7 @@ export default class CalendarConfigBuilder
     nDays: 7,
     eventWidth: 100,
     timeAxisFormatOptions: { hour: 'numeric' },
+    showLocation: false,
   }
   monthGridOptions: MonthGridOptions | undefined
   calendars: Record<string, CalendarType> | undefined

--- a/packages/shared/src/interfaces/calendar/calendar-config.ts
+++ b/packages/shared/src/interfaces/calendar/calendar-config.ts
@@ -21,6 +21,7 @@ export type WeekOptions = {
   nDays: number
   eventWidth: number
   timeAxisFormatOptions: Intl.DateTimeFormatOptions
+  showLocation: boolean
 }
 
 export type MonthGridOptions = {

--- a/packages/theme-default/src/components/calendar/week-grid/time-grid-event.scss
+++ b/packages/theme-default/src/components/calendar/week-grid/time-grid-event.scss
@@ -58,7 +58,8 @@
 }
 
 .sx__time-grid-event-time,
-.sx__time-grid-event-people {
+.sx__time-grid-event-people,
+.sx__time-grid-event-location {
   display: flex;
   align-items: center;
   white-space: nowrap;

--- a/website/pages/docs/calendar/configuration.mdx
+++ b/website/pages/docs/calendar/configuration.mdx
@@ -90,6 +90,12 @@ const config = {
     * Default: { hour: 'numeric' }
     */
     timeAxisFormatOptions: { hour: '2-digit', minute: '2-digit' },
+
+    /**
+    * Show the location of the events in the week grid
+    * Defaults to false
+    */
+    showLocation: true,
   },
 
   monthGridOptions: {


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR).
- [x] But there was a relevant issue already open.
- [x] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

This PR add a possibility to display the location information in the events in the week/day views. It is controlled by a new config option which is false by default to be backward compatible.

## How to test this PR**. 

For example:  
1. Create a calendar with `viewWeek` and an event with non-empty `location`.
2. Location is not displayed by default.
3. Set `{ weekOptions: { showLocation: true } }`.
4. Now location is displayed.
