### PR TITLE
feat: implement "clicking" on events with keyboard (#636)

### DIFF
--- a/packages/calendar/src/components/week-grid/date-grid-event.tsx
+++ b/packages/calendar/src/components/week-grid/date-grid-event.tsx
@@ -36,8 +36,9 @@ export default function DateGridEvent({
   const {
     eventCopy,
     updateCopy,
-    setClickedEventIfNotDragging,
     createDragStartTimeout,
+    setClickedEventIfNotDragging,
+    setClickedEvent,
   } = useEventInteractions($app)
 
   const eventCSSVariables = {
@@ -95,6 +96,14 @@ export default function DateGridEvent({
     )
   }
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.stopPropagation()
+      setClickedEvent(e, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent)
+    }
+  }
+
   const eventClasses = [
     'sx__event',
     'sx__date-grid-event',
@@ -121,6 +130,7 @@ export default function DateGridEvent({
           ' ' +
           getTimeStamp(calendarEvent, $app.config.locale, $app.translate('to'))
         }
+        role="button"
         data-ccid={customComponentId}
         data-event-id={calendarEvent.id}
         onMouseDown={(e) => createDragStartTimeout(handleStartDrag, e)}
@@ -128,6 +138,7 @@ export default function DateGridEvent({
         onTouchStart={(e) => createDragStartTimeout(handleStartDrag, e)}
         onTouchEnd={(e) => setClickedEventIfNotDragging(calendarEvent, e)}
         onClick={() => invokeOnEventClickCallback($app, calendarEvent)}
+        onKeyDown={handleKeyDown}
         className={eventClasses.join(' ')}
         style={{
           width: `calc(${

--- a/packages/calendar/src/components/week-grid/time-grid-event.tsx
+++ b/packages/calendar/src/components/week-grid/time-grid-event.tsx
@@ -45,6 +45,7 @@ export default function TimeGridEvent({
     updateCopy,
     createDragStartTimeout,
     setClickedEventIfNotDragging,
+    setClickedEvent,
   } = useEventInteractions($app)
 
   const localizeArgs = [
@@ -108,6 +109,14 @@ export default function TimeGridEvent({
     invokeOnEventClickCallback($app, calendarEvent)
   }
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.stopPropagation()
+      setClickedEvent(e, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent)
+    }
+  }
+
   const startResize = (e: MouseEvent) => {
     setMouseDown(true)
     e.stopPropagation()
@@ -151,12 +160,14 @@ export default function TimeGridEvent({
         }
         data-event-id={calendarEvent.id}
         onClick={handleOnClick}
+        onKeyDown={handleKeyDown}
         onMouseDown={handlePointerDown}
         onMouseUp={handlePointerUp}
         onTouchStart={handlePointerDown}
         onTouchEnd={handlePointerUp}
         className={classNames.join(' ')}
         tabIndex={0}
+        role="button"
         style={{
           top: `${getYCoordinateInTimeGrid(
             calendarEvent.start,

--- a/packages/calendar/src/views/month-agenda/components/month-agenda-event.tsx
+++ b/packages/calendar/src/views/month-agenda/components/month-agenda-event.tsx
@@ -36,8 +36,16 @@ export default function MonthAgendaEvent({ calendarEvent }: props) {
   }, [calendarEvent])
 
   const onClick = (e: MouseEvent) => {
-    invokeOnEventClickCallback($app, calendarEvent)
     setClickedEvent(e, calendarEvent)
+    invokeOnEventClickCallback($app, calendarEvent)
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.stopPropagation()
+      setClickedEvent(e, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent)
+    }
   }
 
   return (
@@ -54,7 +62,9 @@ export default function MonthAgendaEvent({ calendarEvent }: props) {
         padding: customComponent ? '0px' : undefined,
       }}
       onClick={(e) => onClick(e)}
+      onKeyDown={onKeyDown}
       tabIndex={0}
+      role="button"
     >
       {!customComponent && (
         <Fragment>

--- a/packages/calendar/src/views/month-grid/components/month-grid-event.tsx
+++ b/packages/calendar/src/views/month-grid/components/month-grid-event.tsx
@@ -34,8 +34,11 @@ export default function MonthGridEvent({
     $app.calendarState.range.value?.end &&
     dateFromDateTime(calendarEvent.end) >
       dateFromDateTime($app.calendarState.range.value.end)
-  const { createDragStartTimeout, setClickedEventIfNotDragging } =
-    useEventInteractions($app)
+  const {
+    createDragStartTimeout,
+    setClickedEventIfNotDragging,
+    setClickedEvent,
+  } = useEventInteractions($app)
 
   const hasStartDate = dateFromDateTime(calendarEvent.start) === date
   const nDays = calendarEvent._eventFragments[date]
@@ -82,6 +85,14 @@ export default function MonthGridEvent({
     invokeOnEventClickCallback($app, calendarEvent)
   }
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.stopPropagation()
+      setClickedEvent(e, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent)
+    }
+  }
+
   const classNames = [
     'sx__event',
     'sx__month-grid-event',
@@ -103,6 +114,7 @@ export default function MonthGridEvent({
       onTouchStart={(e) => createDragStartTimeout(handleStartDrag, e)}
       onTouchEnd={(e) => setClickedEventIfNotDragging(calendarEvent, e)}
       onClick={handleOnClick}
+      onKeyDown={handleKeyDown}
       className={classNames.join(' ')}
       style={{
         gridRow,
@@ -115,6 +127,7 @@ export default function MonthGridEvent({
           : eventCSSVariables.backgroundColor,
       }}
       tabIndex={0}
+      role="button"
     >
       {!customComponent && (
         <div className="sx__month-grid-event-title">{calendarEvent.title}</div>


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [x] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

See #636.

I don't quite know how to create tests for this change. I tested manually with all kind of events in all kind of views.

## How to test this PR**. 

1. Create a calendar with full-day and normal events and different views.
2. Add the event modal plugin or add some logging in `callbacks.onEventClick`. (Or both, as these are different mechanisms!)
3. Navigate by pressing Tab repeatedly to an event. Press Space or Enter.
4. Observe the modal to pop up and the callback being called.
