### PR TITLE
fix: prevent positionInTimeGrid from crashing

### DIFF
--- a/packages/calendar/src/utils/stateless/events/__test__/position-in-time-grid.spec.ts
+++ b/packages/calendar/src/utils/stateless/events/__test__/position-in-time-grid.spec.ts
@@ -1,0 +1,41 @@
+/* eslint-disable max-lines */
+import {
+  describe,
+  expect,
+  it,
+} from '@schedule-x/shared/src/utils/stateless/testing/unit/unit-testing-library.impl'
+import CalendarEventBuilder from '../../../../../../shared/src/utils/stateless/calendar/calendar-event/calendar-event.builder'
+import CalendarConfigBuilder from '../../../stateful/config/calendar-config.builder'
+import { positionInTimeGrid } from '../position-in-time-grid'
+import { __createAppWithViews__ } from '../../testing/__create-app-with-views__'
+
+describe('Position in time grid', () => {
+  const _config = new CalendarConfigBuilder().build()
+  const createEvent = (event: { start: string; end: string; id: string }) => {
+    return new CalendarEventBuilder(
+      _config,
+      event.id,
+      event.start,
+      event.end
+    ).build()
+  }
+
+  const selectedDate = '2020-01-01'
+  const $app = __createAppWithViews__({
+    selectedDate,
+  })
+
+  it('should not add time grid events if date event date does not exist in given week', () => {
+    const timeEvent1 = {
+      start: '2020-01-01 00:00',
+      end: '2020-01-01 01:00',
+      id: '1',
+    }
+    const event1 = createEvent(timeEvent1)
+
+    const week = {}
+    const result = positionInTimeGrid([event1], week, $app)
+
+    expect(result).toEqual({})
+  })
+})

--- a/packages/calendar/src/utils/stateless/events/position-in-time-grid.ts
+++ b/packages/calendar/src/utils/stateless/events/position-in-time-grid.ts
@@ -25,7 +25,7 @@ export const positionInTimeGrid = (
       ) {
         date = addDays(date, -1)
       }
-      week[date].timeGridEvents.push(event)
+      week[date]?.timeGridEvents.push(event)
     }
   }
 


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [ ] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

Insert your description or reference to the issue here.
In some cases the `positionInTimeGrid` function of the calendar will try to add events into the `timeGridEvents` on the given week object where the key might not exist.

## How to test this PR**. 

Cause the event state of the calendar to be out of sync with the calendarState.range value. This could be achieved by using the EventServicePlugin in combination with the CalendarControlsPlugin.

Not sure how to easily provide a reproducable example as this happens somewhat deeply in our vue prod code. The unit test should encapsulate the issue. When initially writing it the test crashed with: `TypeError: Cannot read properties of undefined (reading 'timeGridEvents')`
