### PR TITLE
add usage trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Website for documentation and demo: https://schedule-x.dev/
 
 ![Schedule-X calendar demo](https://schedule-x.s3.eu-west-1.amazonaws.com/schedule-x-demo-readme-480p-15fps.gif)
 
+## Usage Trend
+[Usage Trend of schedule-x Family](https://npm-compare.com/@schedule-x/angular,@schedule-x/calendar,@schedule-x/events-service,@schedule-x/preact,@schedule-x/react,@schedule-x/svelte,@schedule-x/theme-default,@schedule-x/vue)
+
 ## Contact
 
 For bug reports and feature requests, please use the issue tracker of this repository.


### PR DESCRIPTION
I'm the maintainer of npm-compare.com, a website that helps developers track npm usage trends. I’ve added a section to the README that links to the usage trends for the Schedule-X packages. This addition will help users easily view usage trend of the `schedule-x` ecosystem.

I also wanted to mention that if you are interested, I can help build new features or enhance the npm-compare platform in ways that could support your project. Feel free to reach out if you’d like to explore collaboration opportunities.
