### PR TITLE
feat: allow fine grained configuration of drag-and-drop-plugin

### DIFF
--- a/packages/drag-and-drop/src/drag-and-drop-plugin.impl.ts
+++ b/packages/drag-and-drop/src/drag-and-drop-plugin.impl.ts
@@ -38,9 +38,14 @@ class DragAndDropPluginImpl implements DragAndDropPlugin {
   }
 
   private getTimePointsForIntervalConfig(): number {
-    if (this.minutesPerInterval === 60) return 100
-    if (this.minutesPerInterval === 30) return 50
-    return 25
+    if (this.minutesPerInterval < 1 || this.minutesPerInterval > 60) {
+      console.warn(
+        `Invalid value for minutesPerInterval: ${this.minutesPerInterval} (must be between 1-60).\nDefaulting to 15 minutes`
+      )
+      this.minutesPerInterval = 15
+    }
+
+    return Math.round((this.minutesPerInterval / 60) * 100)
   }
 
   createDateGridDragHandler(


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [x] I'm a Schedule-X premium user

## This PR solves the following problem**. 
This allows fine grained configuration of the drag and drop plugin. It now allows any value between 1-60 and will default to 15 (the current default) if the value given is outside of the valid range, in which case a warning is printed.

## How to test this PR**. 

For example:  
1. use init createDragAndDropPlugin with any value (1-60)
2. drag an event
3. witness a change in valid time points.
