### PR TITLE
fix(backgroundEvents): clamp background event start and end to dayBoundaries

### DIFF
--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -5,9 +5,7 @@ import '@fontsource/open-sans/500-italic.css'
 import '@fontsource/open-sans/700.css'
 import '@fontsource/open-sans/700-italic.css'
 import '@fontsource/roboto-condensed'
-import {
-  createCalendar,
-} from '@schedule-x/calendar/src'
+import { createCalendar } from '@schedule-x/calendar/src'
 import '../../packages/theme-default/src/calendar.scss'
 import '../app.css'
 import { createDragAndDropPlugin } from '@schedule-x/drag-and-drop/src'
@@ -23,10 +21,10 @@ import { createCalendarControlsPlugin } from '../../packages/calendar-controls/s
 import { CalendarAppSingleton } from '@schedule-x/shared/src'
 import { createCurrentTimePlugin } from '../../packages/current-time/src/current-time-plugin.impl.ts'
 import { createViewMonthGrid } from '@schedule-x/calendar/src/views/month-grid'
-import { createViewWeek } from '@schedule-x/calendar/src/views/week'
+import { createViewWeek, viewWeek } from '@schedule-x/calendar/src/views/week'
 import { createViewDay } from '@schedule-x/calendar/src/views/day'
 import { createViewMonthAgenda } from '@schedule-x/calendar/src/views/month-agenda'
-import {WeekDay} from "@schedule-x/shared/src/enums/time/week-day.enum.ts";
+import { WeekDay } from '@schedule-x/shared/src/enums/time/week-day.enum.ts'
 
 const calendarElement = document.getElementById('calendar') as HTMLElement
 
@@ -68,271 +66,257 @@ const calendarsUpdaterPlugin = new CalendarsUpdaterPlugin()
 const calendarControlsPlugin = createCalendarControlsPlugin()
 const eventsServicePlugin = createEventsServicePlugin()
 
-const calendar = createCalendar({
-  weekOptions: {
-    // gridHeight: 3000,
-    // nDays: 3,
-    eventWidth: 95,
-  },
-  // monthGridOptions: {
-  //   nEventsPerDay: 7
-  // },
-  firstDayOfWeek: 1,
-  // locale: 'de-DE',
-  // locale: 'pt-BR',
-  // locale: 'en-US',
-  // locale: 'zh-CN',
-  // locale: 'id-ID',
-  locale: 'zh-TW',
-  // locale: 'et-EE',
-  // locale: 'ca-ES',
-  views: [createViewMonthGrid(), createViewWeek(), createViewDay(), createViewMonthAgenda()],
-  // defaultView: viewWeek.name,
-  // minDate: '2024-01-01',
-  // maxDate: '2025-03-31',
-  // defaultView: 'month-grid',
-  // selectedDate: '2024-12-01',
-  // datePicker: {
-  //   teleportTo: document.body,
-  // },
-  // dayBoundaries: {
-  //   start: '06:00',
-  //   end: '20:00',
-  // },
-  // isDark: true,
-  callbacks: {
-    // onBeforeEventUpdate(oldEvent, newEvent, $app) {
-    //   return false
+const calendar = createCalendar(
+  {
+    weekOptions: {
+      // gridHeight: 3000,
+      // nDays: 3,
+      eventWidth: 95,
+    },
+    // monthGridOptions: {
+    //   nEventsPerDay: 7
     // },
+    firstDayOfWeek: 1,
+    // locale: 'de-DE',
+    // locale: 'pt-BR',
+    // locale: 'en-US',
+    // locale: 'zh-CN',
+    // locale: 'id-ID',
+    // locale: 'zh-TW',
+    // locale: 'et-EE',
+    // locale: 'ca-ES',
+    views: [
+      createViewMonthGrid(),
+      createViewWeek(),
+      createViewDay(),
+      createViewMonthAgenda(),
+    ],
+    defaultView: viewWeek.name,
+    // minDate: '2024-01-01',
+    // maxDate: '2025-03-31',
+    // defaultView: 'month-grid',
+    // selectedDate: '2024-12-01',
+    // datePicker: {
+    //   teleportTo: document.body,
+    // },
+    // dayBoundaries: {
+    //   start: '06:00',
+    //   end: '20:00',
+    // },
+    // isDark: true,
+    callbacks: {
+      // onBeforeEventUpdate(oldEvent, newEvent, $app) {
+      //   return false
+      // },
 
-    onRangeUpdate(range) {
-      console.log('onRangeUpdate', range)
-    },
+      onRangeUpdate(range) {
+        console.log('onRangeUpdate', range)
+      },
 
-    onEventUpdate(event) {
-      console.log('onEventUpdate', event)
-    },
+      onEventUpdate(event) {
+        console.log('onEventUpdate', event)
+      },
 
-    onEventClick(event) {
-      console.log('onEventClick', event)
-    },
+      onEventClick(event) {
+        console.log('onEventClick', event)
+      },
 
-    onDoubleClickEvent(event) {
-      console.log('onDoubleClickEvent', event)
-    },
+      onDoubleClickEvent(event) {
+        console.log('onDoubleClickEvent', event)
+      },
 
-    onClickDate(date) {
-      console.log('onClickDate', date)
-    },
+      onClickDate(date) {
+        console.log('onClickDate', date)
+      },
 
-    onClickDateTime(dateTime) {
-      console.log('onClickDateTime', dateTime)
-    },
+      onClickDateTime(dateTime) {
+        console.log('onClickDateTime', dateTime)
+      },
 
-    onClickAgendaDate(date) {
-      console.log('onClickAgendaDate', date)
-    },
+      onClickAgendaDate(date) {
+        console.log('onClickAgendaDate', date)
+      },
 
-    onDoubleClickAgendaDate(date) {
-      console.log('onDoubleClickAgendaDate', date)
-    },
+      onDoubleClickAgendaDate(date) {
+        console.log('onDoubleClickAgendaDate', date)
+      },
 
-    onClickPlusEvents(date) {
-      console.log('onClickPlusEvents', date)
-    },
+      onClickPlusEvents(date) {
+        console.log('onClickPlusEvents', date)
+      },
 
-    onSelectedDateUpdate(date) {
-      console.log('onSelectedDateUpdate', date)
-    },
+      onSelectedDateUpdate(date) {
+        console.log('onSelectedDateUpdate', date)
+      },
 
-    onDoubleClickDateTime(dateTime) {
-      console.log('onDoubleClickDateTime', dateTime)
-    },
+      onDoubleClickDateTime(dateTime) {
+        console.log('onDoubleClickDateTime', dateTime)
+      },
 
-    onDoubleClickDate(date) {
-      console.log('onDoubleClickDate', date)
+      onDoubleClickDate(date) {
+        console.log('onDoubleClickDate', date)
+      },
+      //
+      // isCalendarSmall($app) {
+      //   return $app.elements.calendarWrapper!.clientWidth! < 500
+      // }
     },
-    //
-    // isCalendarSmall($app) {
-    //   return $app.elements.calendarWrapper!.clientWidth! < 500
-    // }
+    calendars: {
+      personal: {
+        colorName: 'personal',
+        lightColors: {
+          main: '#f9d71c',
+          container: '#fff5aa',
+          onContainer: '#594800',
+        },
+        darkColors: {
+          main: '#fff5c0',
+          onContainer: '#fff5de',
+          container: '#a29742',
+        },
+      },
+      work: {
+        colorName: 'work',
+        lightColors: {
+          main: '#f91c45',
+          container: '#ffd2dc',
+          onContainer: '#59000d',
+        },
+        darkColors: {
+          main: '#ffc0cc',
+          onContainer: '#ffdee6',
+          container: '#a24258',
+        },
+      },
+      leisure: {
+        colorName: 'leisure',
+        lightColors: {
+          main: '#1cf9b0',
+          container: '#dafff0',
+          onContainer: '#004d3d',
+        },
+        darkColors: {
+          main: '#c0fff5',
+          onContainer: '#e6fff5',
+          container: '#42a297',
+        },
+      },
+      school: {
+        colorName: 'school',
+        lightColors: {
+          main: '#1c7df9',
+          container: '#d2e7ff',
+          onContainer: '#002859',
+        },
+        darkColors: {
+          main: '#c0dfff',
+          onContainer: '#dee6ff',
+          container: '#426aa2',
+        },
+      },
+    },
+    dayBoundaries: {
+      start: '10:00',
+      end: '20:00',
+    },
+    backgroundEvents: [
+      {
+        title: 'Out of office',
+        start: '2024-12-18 00:00',
+        end: '2024-12-18 12:00',
+        style: { backgroundColor: 'red', opacity: 0.05 },
+      },
+      {
+        start: '2024-12-18 15:00',
+        end: '2024-12-18 23:59',
+        style: { backgroundColor: 'red', opacity: 0.05 },
+      },
+    ],
+    events: [
+      {
+        id: 874574875,
+        start: '2024-09-09 07:45',
+        end: '2024-09-09 09:01',
+        _customContent: {
+          timeGrid: '<div class="custom-content">Custom Content</div>',
+          monthGrid: '<div class="custom-content">Custom Content</div>',
+        },
+      },
+      {
+        id: 874574875,
+        start: '2024-09-09',
+        end: '2024-09-09',
+        title: 'All Day Event',
+        _customContent: {
+          dateGrid: '<div class="custom-content">Custom Content</div>',
+          monthAgenda: '<div class="custom-content">Custom Content</div>',
+        },
+      },
+      ...seededEvents,
+      {
+        id: 45678,
+        title: 'Bi-Weekly Event Monday and Wednesday',
+        start: '2024-03-19 14:00',
+        end: '2024-03-19 15:00',
+        rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
+      },
+      {
+        id: 18547854,
+        title: 'Bi-Weekly Event Monday and Wednesday',
+        start: '2024-02-05 14:00',
+        end: '2024-02-05 15:00',
+        rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
+      },
+      {
+        id: 18547855,
+        title: 'Weekly Event',
+        start: '2024-02-03',
+        end: '2024-02-03',
+        rrule: 'FREQ=WEEKLY;COUNT=4',
+      },
+      {
+        id: 789,
+        title: 'Daily event',
+        start: '2024-02-05 12:00',
+        end: '2024-02-05 13:55',
+        rrule: 'FREQ=DAILY;COUNT=5',
+        calendarId: 'personal',
+      },
+      {
+        id: 9834876578,
+        title: 'Daily event 2',
+        start: '2024-02-05 12:00',
+        end: '2024-02-05 13:55',
+        rrule: 'FREQ=DAILY;UNTIL=20240209T235900',
+        calendarId: 'work',
+      },
+      {
+        id: 7845684678465874,
+        title: 'Monthly event',
+        start: '2024-02-07 16:00',
+        end: '2024-02-07 17:55',
+        rrule: 'FREQ=MONTHLY;COUNT=5',
+      },
+      {
+        rrule: 'FREQ=YEARLY;COUNT=5',
+        title: 'Yearly event',
+        start: '2024-02-08 16:00',
+        end: '2024-02-08 17:55',
+        id: 874367853,
+      },
+    ],
   },
-  calendars: {
-    personal: {
-      colorName: 'personal',
-      lightColors: {
-        main: '#f9d71c',
-        container: '#fff5aa',
-        onContainer: '#594800',
-      },
-      darkColors: {
-        main: '#fff5c0',
-        onContainer: '#fff5de',
-        container: '#a29742',
-      },
-    },
-    work: {
-      colorName: 'work',
-      lightColors: {
-        main: '#f91c45',
-        container: '#ffd2dc',
-        onContainer: '#59000d',
-      },
-      darkColors: {
-        main: '#ffc0cc',
-        onContainer: '#ffdee6',
-        container: '#a24258',
-      },
-    },
-    leisure: {
-      colorName: 'leisure',
-      lightColors: {
-        main: '#1cf9b0',
-        container: '#dafff0',
-        onContainer: '#004d3d',
-      },
-      darkColors: {
-        main: '#c0fff5',
-        onContainer: '#e6fff5',
-        container: '#42a297',
-      },
-    },
-    school: {
-      colorName: 'school',
-      lightColors: {
-        main: '#1c7df9',
-        container: '#d2e7ff',
-        onContainer: '#002859',
-      },
-      darkColors: {
-        main: '#c0dfff',
-        onContainer: '#dee6ff',
-        container: '#426aa2',
-      },
-    },
-  },
-  backgroundEvents: [
-    {
-      title: 'Out of office',
-      start: '2024-09-03',
-      end: '2024-09-03',
-      style: {
-        // create tilted 5px thick gray lines
-        backgroundImage: 'repeating-linear-gradient(45deg, #ccc, #ccc 5px, transparent 5px, transparent 10px)',
-        opacity: 0.5,
-      },
-    },
-    {
-      title: 'Out of office',
-      start: '2024-09-02 00:00',
-      end: '2024-09-02 02:00',
-      style: {
-        background: 'linear-gradient(45deg, #f91c45, #1c7df9)',
-        opacity: 0.5,
-      },
-    },
-    {
-      title: 'Out of office',
-      start: '2024-09-02 04:00',
-      end: '2024-09-02 07:00',
-      style: {
-        backgroundColor: '#f91c45',
-        opacity: 0.5,
-      },
-    },
-    {
-      title: 'Holiday',
-      start: '2024-09-05',
-      end: '2024-09-07',
-      style: {
-        backgroundImage: 'repeating-linear-gradient(45deg, #1cf9b0, #1cf9b0 5px, transparent 5px, transparent 10px)',
-        opacity: 0.5,
-      },
-    }
-  ],
-  events: [
-    {
-      id: 874574875,
-      start: '2024-09-09 07:45',
-      end: '2024-09-09 09:01',
-      _customContent: {
-        timeGrid: '<div class="custom-content">Custom Content</div>',
-        monthGrid: '<div class="custom-content">Custom Content</div>',
-      }
-    },
-    {
-      id: 874574875,
-      start: '2024-09-09',
-      end: '2024-09-09',
-      title: 'All Day Event',
-      _customContent: {
-        dateGrid: '<div class="custom-content">Custom Content</div>',
-        monthAgenda: '<div class="custom-content">Custom Content</div>',
-      }
-    },
-    ...seededEvents,
-    {
-      id: 45678,
-      title: 'Bi-Weekly Event Monday and Wednesday',
-      start: '2024-03-19 14:00',
-      end: '2024-03-19 15:00',
-      rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
-    },
-    {
-      id: 18547854,
-      title: 'Bi-Weekly Event Monday and Wednesday',
-      start: '2024-02-05 14:00',
-      end: '2024-02-05 15:00',
-      rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
-    },
-    {
-      id: 18547855,
-      title: 'Weekly Event',
-      start: '2024-02-03',
-      end: '2024-02-03',
-      rrule: 'FREQ=WEEKLY;COUNT=4',
-    },
-    {
-      id: 789,
-      title: 'Daily event',
-      start: '2024-02-05 12:00',
-      end: '2024-02-05 13:55',
-      rrule: 'FREQ=DAILY;COUNT=5',
-      calendarId: 'personal',
-    },
-    {
-      id: 9834876578,
-      title: 'Daily event 2',
-      start: '2024-02-05 12:00',
-      end: '2024-02-05 13:55',
-      rrule: 'FREQ=DAILY;UNTIL=20240209T235900',
-      calendarId: 'work',
-    },
-    {
-      id: 7845684678465874,
-      title: 'Monthly event',
-      start: '2024-02-07 16:00',
-      end: '2024-02-07 17:55',
-      rrule: 'FREQ=MONTHLY;COUNT=5',
-    },
-    {
-      rrule: 'FREQ=YEARLY;COUNT=5',
-      title: 'Yearly event',
-      start: '2024-02-08 16:00',
-      end: '2024-02-08 17:55',
-      id: 874367853,
-    },
-  ],
-}, [
-  createDragAndDropPlugin(),
-  createCalendarControlsPlugin(),
-  createScrollControllerPlugin(),
-  createEventsServicePlugin(),
-  createCurrentTimePlugin(),
-  createEventModalPlugin(),
-  createEventRecurrencePlugin(),
-  createResizePlugin(),
-])
+  [
+    createDragAndDropPlugin(),
+    createCalendarControlsPlugin(),
+    createScrollControllerPlugin(),
+    createEventsServicePlugin(),
+    createCurrentTimePlugin(),
+    createEventModalPlugin(),
+    createEventRecurrencePlugin(),
+    createResizePlugin(),
+  ]
+)
 calendar.render(calendarElement)
 
 // const calendar2Element = document.getElementById('calendar-2') as HTMLElement
@@ -393,40 +377,54 @@ setViewButton.addEventListener('click', () => {
 })
 
 const setFirstDayOfWeekButton = document.getElementById(
-    'set-first-day-of-week-button'
+  'set-first-day-of-week-button'
 ) as HTMLButtonElement
 setFirstDayOfWeekButton.addEventListener('click', () => {
-  const newFirstDayOfWeek = (document.getElementById('set-first-day-of-week') as HTMLInputElement)
-      .value
-  calendarControlsPlugin.setFirstDayOfWeek(parseInt(newFirstDayOfWeek, 10) as WeekDay)
+  const newFirstDayOfWeek = (
+    document.getElementById('set-first-day-of-week') as HTMLInputElement
+  ).value
+  calendarControlsPlugin.setFirstDayOfWeek(
+    parseInt(newFirstDayOfWeek, 10) as WeekDay
+  )
 })
 
 const setNDaysButton = document.getElementById(
-    'set-n-days-button'
+  'set-n-days-button'
 ) as HTMLButtonElement
 setNDaysButton.addEventListener('click', () => {
   const newNDays = (document.getElementById('set-n-days') as HTMLInputElement)
-      .value as unknown as number
-  calendarControlsPlugin.setWeekOptions({...calendarControlsPlugin.getWeekOptions(), nDays: newNDays})
+    .value as unknown as number
+  calendarControlsPlugin.setWeekOptions({
+    ...calendarControlsPlugin.getWeekOptions(),
+    nDays: newNDays,
+  })
 })
 
 const setLocaleSelect = document.getElementById(
-    'set-locale'
+  'set-locale'
 ) as HTMLSelectElement
 setLocaleSelect.addEventListener('change', () => {
-  const newLocale = (document.getElementById('set-locale') as HTMLSelectElement).value
+  const newLocale = (document.getElementById('set-locale') as HTMLSelectElement)
+    .value
   calendarControlsPlugin.setLocale(newLocale)
 })
 
 const setDayBoundariesButton = document.getElementById(
-    'set-day-boundaries-button'
+  'set-day-boundaries-button'
 ) as HTMLButtonElement
 
 setDayBoundariesButton.addEventListener('click', () => {
-  const newDayBoundariesStart = (document.getElementById('set-day-boundaries-start') as HTMLInputElement).value
-  const newDayBoundariesEnd = (document.getElementById('set-day-boundaries-end') as HTMLInputElement).value
+  const newDayBoundariesStart = (
+    document.getElementById('set-day-boundaries-start') as HTMLInputElement
+  ).value
+  const newDayBoundariesEnd = (
+    document.getElementById('set-day-boundaries-end') as HTMLInputElement
+  ).value
 
-  calendarControlsPlugin.setDayBoundaries({start: `${newDayBoundariesStart.padStart(2, '0')}:00`, end: `${newDayBoundariesEnd.padStart(2, '0')}:00`})
+  calendarControlsPlugin.setDayBoundaries({
+    start: `${newDayBoundariesStart.padStart(2, '0')}:00`,
+    end: `${newDayBoundariesEnd.padStart(2, '0')}:00`,
+  })
 })
 
 const updateCalendarsButton = document.getElementById(
@@ -476,6 +474,6 @@ updateBackgroundEventsButton.addEventListener('click', () => {
         backgroundColor: '#f9501c',
         opacity: 0.5,
       },
-    }
+    },
   ])
 })

--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -5,7 +5,9 @@ import '@fontsource/open-sans/500-italic.css'
 import '@fontsource/open-sans/700.css'
 import '@fontsource/open-sans/700-italic.css'
 import '@fontsource/roboto-condensed'
-import { createCalendar } from '@schedule-x/calendar/src'
+import {
+  createCalendar,
+} from '@schedule-x/calendar/src'
 import '../../packages/theme-default/src/calendar.scss'
 import '../app.css'
 import { createDragAndDropPlugin } from '@schedule-x/drag-and-drop/src'
@@ -21,10 +23,10 @@ import { createCalendarControlsPlugin } from '../../packages/calendar-controls/s
 import { CalendarAppSingleton } from '@schedule-x/shared/src'
 import { createCurrentTimePlugin } from '../../packages/current-time/src/current-time-plugin.impl.ts'
 import { createViewMonthGrid } from '@schedule-x/calendar/src/views/month-grid'
-import { createViewWeek, viewWeek } from '@schedule-x/calendar/src/views/week'
+import { createViewWeek } from '@schedule-x/calendar/src/views/week'
 import { createViewDay } from '@schedule-x/calendar/src/views/day'
 import { createViewMonthAgenda } from '@schedule-x/calendar/src/views/month-agenda'
-import { WeekDay } from '@schedule-x/shared/src/enums/time/week-day.enum.ts'
+import {WeekDay} from "@schedule-x/shared/src/enums/time/week-day.enum.ts";
 
 const calendarElement = document.getElementById('calendar') as HTMLElement
 
@@ -66,257 +68,271 @@ const calendarsUpdaterPlugin = new CalendarsUpdaterPlugin()
 const calendarControlsPlugin = createCalendarControlsPlugin()
 const eventsServicePlugin = createEventsServicePlugin()
 
-const calendar = createCalendar(
-  {
-    weekOptions: {
-      // gridHeight: 3000,
-      // nDays: 3,
-      eventWidth: 95,
-    },
-    // monthGridOptions: {
-    //   nEventsPerDay: 7
-    // },
-    firstDayOfWeek: 1,
-    // locale: 'de-DE',
-    // locale: 'pt-BR',
-    // locale: 'en-US',
-    // locale: 'zh-CN',
-    // locale: 'id-ID',
-    // locale: 'zh-TW',
-    // locale: 'et-EE',
-    // locale: 'ca-ES',
-    views: [
-      createViewMonthGrid(),
-      createViewWeek(),
-      createViewDay(),
-      createViewMonthAgenda(),
-    ],
-    defaultView: viewWeek.name,
-    // minDate: '2024-01-01',
-    // maxDate: '2025-03-31',
-    // defaultView: 'month-grid',
-    // selectedDate: '2024-12-01',
-    // datePicker: {
-    //   teleportTo: document.body,
-    // },
-    // dayBoundaries: {
-    //   start: '06:00',
-    //   end: '20:00',
-    // },
-    // isDark: true,
-    callbacks: {
-      // onBeforeEventUpdate(oldEvent, newEvent, $app) {
-      //   return false
-      // },
-
-      onRangeUpdate(range) {
-        console.log('onRangeUpdate', range)
-      },
-
-      onEventUpdate(event) {
-        console.log('onEventUpdate', event)
-      },
-
-      onEventClick(event) {
-        console.log('onEventClick', event)
-      },
-
-      onDoubleClickEvent(event) {
-        console.log('onDoubleClickEvent', event)
-      },
-
-      onClickDate(date) {
-        console.log('onClickDate', date)
-      },
-
-      onClickDateTime(dateTime) {
-        console.log('onClickDateTime', dateTime)
-      },
-
-      onClickAgendaDate(date) {
-        console.log('onClickAgendaDate', date)
-      },
-
-      onDoubleClickAgendaDate(date) {
-        console.log('onDoubleClickAgendaDate', date)
-      },
-
-      onClickPlusEvents(date) {
-        console.log('onClickPlusEvents', date)
-      },
-
-      onSelectedDateUpdate(date) {
-        console.log('onSelectedDateUpdate', date)
-      },
-
-      onDoubleClickDateTime(dateTime) {
-        console.log('onDoubleClickDateTime', dateTime)
-      },
-
-      onDoubleClickDate(date) {
-        console.log('onDoubleClickDate', date)
-      },
-      //
-      // isCalendarSmall($app) {
-      //   return $app.elements.calendarWrapper!.clientWidth! < 500
-      // }
-    },
-    calendars: {
-      personal: {
-        colorName: 'personal',
-        lightColors: {
-          main: '#f9d71c',
-          container: '#fff5aa',
-          onContainer: '#594800',
-        },
-        darkColors: {
-          main: '#fff5c0',
-          onContainer: '#fff5de',
-          container: '#a29742',
-        },
-      },
-      work: {
-        colorName: 'work',
-        lightColors: {
-          main: '#f91c45',
-          container: '#ffd2dc',
-          onContainer: '#59000d',
-        },
-        darkColors: {
-          main: '#ffc0cc',
-          onContainer: '#ffdee6',
-          container: '#a24258',
-        },
-      },
-      leisure: {
-        colorName: 'leisure',
-        lightColors: {
-          main: '#1cf9b0',
-          container: '#dafff0',
-          onContainer: '#004d3d',
-        },
-        darkColors: {
-          main: '#c0fff5',
-          onContainer: '#e6fff5',
-          container: '#42a297',
-        },
-      },
-      school: {
-        colorName: 'school',
-        lightColors: {
-          main: '#1c7df9',
-          container: '#d2e7ff',
-          onContainer: '#002859',
-        },
-        darkColors: {
-          main: '#c0dfff',
-          onContainer: '#dee6ff',
-          container: '#426aa2',
-        },
-      },
-    },
-    dayBoundaries: {
-      start: '10:00',
-      end: '20:00',
-    },
-    backgroundEvents: [
-      {
-        title: 'Out of office',
-        start: '2024-12-18 00:00',
-        end: '2024-12-18 12:00',
-        style: { backgroundColor: 'red', opacity: 0.05 },
-      },
-      {
-        start: '2024-12-18 15:00',
-        end: '2024-12-18 23:59',
-        style: { backgroundColor: 'red', opacity: 0.05 },
-      },
-    ],
-    events: [
-      {
-        id: 874574875,
-        start: '2024-09-09 07:45',
-        end: '2024-09-09 09:01',
-        _customContent: {
-          timeGrid: '<div class="custom-content">Custom Content</div>',
-          monthGrid: '<div class="custom-content">Custom Content</div>',
-        },
-      },
-      {
-        id: 874574875,
-        start: '2024-09-09',
-        end: '2024-09-09',
-        title: 'All Day Event',
-        _customContent: {
-          dateGrid: '<div class="custom-content">Custom Content</div>',
-          monthAgenda: '<div class="custom-content">Custom Content</div>',
-        },
-      },
-      ...seededEvents,
-      {
-        id: 45678,
-        title: 'Bi-Weekly Event Monday and Wednesday',
-        start: '2024-03-19 14:00',
-        end: '2024-03-19 15:00',
-        rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
-      },
-      {
-        id: 18547854,
-        title: 'Bi-Weekly Event Monday and Wednesday',
-        start: '2024-02-05 14:00',
-        end: '2024-02-05 15:00',
-        rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
-      },
-      {
-        id: 18547855,
-        title: 'Weekly Event',
-        start: '2024-02-03',
-        end: '2024-02-03',
-        rrule: 'FREQ=WEEKLY;COUNT=4',
-      },
-      {
-        id: 789,
-        title: 'Daily event',
-        start: '2024-02-05 12:00',
-        end: '2024-02-05 13:55',
-        rrule: 'FREQ=DAILY;COUNT=5',
-        calendarId: 'personal',
-      },
-      {
-        id: 9834876578,
-        title: 'Daily event 2',
-        start: '2024-02-05 12:00',
-        end: '2024-02-05 13:55',
-        rrule: 'FREQ=DAILY;UNTIL=20240209T235900',
-        calendarId: 'work',
-      },
-      {
-        id: 7845684678465874,
-        title: 'Monthly event',
-        start: '2024-02-07 16:00',
-        end: '2024-02-07 17:55',
-        rrule: 'FREQ=MONTHLY;COUNT=5',
-      },
-      {
-        rrule: 'FREQ=YEARLY;COUNT=5',
-        title: 'Yearly event',
-        start: '2024-02-08 16:00',
-        end: '2024-02-08 17:55',
-        id: 874367853,
-      },
-    ],
+const calendar = createCalendar({
+  weekOptions: {
+    // gridHeight: 3000,
+    // nDays: 3,
+    eventWidth: 95,
   },
-  [
-    createDragAndDropPlugin(),
-    createCalendarControlsPlugin(),
-    createScrollControllerPlugin(),
-    createEventsServicePlugin(),
-    createCurrentTimePlugin(),
-    createEventModalPlugin(),
-    createEventRecurrencePlugin(),
-    createResizePlugin(),
-  ]
-)
+  // monthGridOptions: {
+  //   nEventsPerDay: 7
+  // },
+  firstDayOfWeek: 1,
+  // locale: 'de-DE',
+  // locale: 'pt-BR',
+  // locale: 'en-US',
+  // locale: 'zh-CN',
+  // locale: 'id-ID',
+  locale: 'zh-TW',
+  // locale: 'et-EE',
+  // locale: 'ca-ES',
+  views: [createViewMonthGrid(), createViewWeek(), createViewDay(), createViewMonthAgenda()],
+  // defaultView: viewWeek.name,
+  // minDate: '2024-01-01',
+  // maxDate: '2025-03-31',
+  // defaultView: 'month-grid',
+  // selectedDate: '2024-12-01',
+  // datePicker: {
+  //   teleportTo: document.body,
+  // },
+  // dayBoundaries: {
+  //   start: '06:00',
+  //   end: '20:00',
+  // },
+  // isDark: true,
+  callbacks: {
+    // onBeforeEventUpdate(oldEvent, newEvent, $app) {
+    //   return false
+    // },
+
+    onRangeUpdate(range) {
+      console.log('onRangeUpdate', range)
+    },
+
+    onEventUpdate(event) {
+      console.log('onEventUpdate', event)
+    },
+
+    onEventClick(event) {
+      console.log('onEventClick', event)
+    },
+
+    onDoubleClickEvent(event) {
+      console.log('onDoubleClickEvent', event)
+    },
+
+    onClickDate(date) {
+      console.log('onClickDate', date)
+    },
+
+    onClickDateTime(dateTime) {
+      console.log('onClickDateTime', dateTime)
+    },
+
+    onClickAgendaDate(date) {
+      console.log('onClickAgendaDate', date)
+    },
+
+    onDoubleClickAgendaDate(date) {
+      console.log('onDoubleClickAgendaDate', date)
+    },
+
+    onClickPlusEvents(date) {
+      console.log('onClickPlusEvents', date)
+    },
+
+    onSelectedDateUpdate(date) {
+      console.log('onSelectedDateUpdate', date)
+    },
+
+    onDoubleClickDateTime(dateTime) {
+      console.log('onDoubleClickDateTime', dateTime)
+    },
+
+    onDoubleClickDate(date) {
+      console.log('onDoubleClickDate', date)
+    },
+    //
+    // isCalendarSmall($app) {
+    //   return $app.elements.calendarWrapper!.clientWidth! < 500
+    // }
+  },
+  calendars: {
+    personal: {
+      colorName: 'personal',
+      lightColors: {
+        main: '#f9d71c',
+        container: '#fff5aa',
+        onContainer: '#594800',
+      },
+      darkColors: {
+        main: '#fff5c0',
+        onContainer: '#fff5de',
+        container: '#a29742',
+      },
+    },
+    work: {
+      colorName: 'work',
+      lightColors: {
+        main: '#f91c45',
+        container: '#ffd2dc',
+        onContainer: '#59000d',
+      },
+      darkColors: {
+        main: '#ffc0cc',
+        onContainer: '#ffdee6',
+        container: '#a24258',
+      },
+    },
+    leisure: {
+      colorName: 'leisure',
+      lightColors: {
+        main: '#1cf9b0',
+        container: '#dafff0',
+        onContainer: '#004d3d',
+      },
+      darkColors: {
+        main: '#c0fff5',
+        onContainer: '#e6fff5',
+        container: '#42a297',
+      },
+    },
+    school: {
+      colorName: 'school',
+      lightColors: {
+        main: '#1c7df9',
+        container: '#d2e7ff',
+        onContainer: '#002859',
+      },
+      darkColors: {
+        main: '#c0dfff',
+        onContainer: '#dee6ff',
+        container: '#426aa2',
+      },
+    },
+  },
+  backgroundEvents: [
+    {
+      title: 'Out of office',
+      start: '2024-09-03',
+      end: '2024-09-03',
+      style: {
+        // create tilted 5px thick gray lines
+        backgroundImage: 'repeating-linear-gradient(45deg, #ccc, #ccc 5px, transparent 5px, transparent 10px)',
+        opacity: 0.5,
+      },
+    },
+    {
+      title: 'Out of office',
+      start: '2024-09-02 00:00',
+      end: '2024-09-02 02:00',
+      style: {
+        background: 'linear-gradient(45deg, #f91c45, #1c7df9)',
+        opacity: 0.5,
+      },
+    },
+    {
+      title: 'Out of office',
+      start: '2024-09-02 04:00',
+      end: '2024-09-02 07:00',
+      style: {
+        backgroundColor: '#f91c45',
+        opacity: 0.5,
+      },
+    },
+    {
+      title: 'Holiday',
+      start: '2024-09-05',
+      end: '2024-09-07',
+      style: {
+        backgroundImage: 'repeating-linear-gradient(45deg, #1cf9b0, #1cf9b0 5px, transparent 5px, transparent 10px)',
+        opacity: 0.5,
+      },
+    }
+  ],
+  events: [
+    {
+      id: 874574875,
+      start: '2024-09-09 07:45',
+      end: '2024-09-09 09:01',
+      _customContent: {
+        timeGrid: '<div class="custom-content">Custom Content</div>',
+        monthGrid: '<div class="custom-content">Custom Content</div>',
+      }
+    },
+    {
+      id: 874574875,
+      start: '2024-09-09',
+      end: '2024-09-09',
+      title: 'All Day Event',
+      _customContent: {
+        dateGrid: '<div class="custom-content">Custom Content</div>',
+        monthAgenda: '<div class="custom-content">Custom Content</div>',
+      }
+    },
+    ...seededEvents,
+    {
+      id: 45678,
+      title: 'Bi-Weekly Event Monday and Wednesday',
+      start: '2024-03-19 14:00',
+      end: '2024-03-19 15:00',
+      rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
+    },
+    {
+      id: 18547854,
+      title: 'Bi-Weekly Event Monday and Wednesday',
+      start: '2024-02-05 14:00',
+      end: '2024-02-05 15:00',
+      rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE;UNTIL=20240229T235959',
+    },
+    {
+      id: 18547855,
+      title: 'Weekly Event',
+      start: '2024-02-03',
+      end: '2024-02-03',
+      rrule: 'FREQ=WEEKLY;COUNT=4',
+    },
+    {
+      id: 789,
+      title: 'Daily event',
+      start: '2024-02-05 12:00',
+      end: '2024-02-05 13:55',
+      rrule: 'FREQ=DAILY;COUNT=5',
+      calendarId: 'personal',
+    },
+    {
+      id: 9834876578,
+      title: 'Daily event 2',
+      start: '2024-02-05 12:00',
+      end: '2024-02-05 13:55',
+      rrule: 'FREQ=DAILY;UNTIL=20240209T235900',
+      calendarId: 'work',
+    },
+    {
+      id: 7845684678465874,
+      title: 'Monthly event',
+      start: '2024-02-07 16:00',
+      end: '2024-02-07 17:55',
+      rrule: 'FREQ=MONTHLY;COUNT=5',
+    },
+    {
+      rrule: 'FREQ=YEARLY;COUNT=5',
+      title: 'Yearly event',
+      start: '2024-02-08 16:00',
+      end: '2024-02-08 17:55',
+      id: 874367853,
+    },
+  ],
+}, [
+  createDragAndDropPlugin(),
+  createCalendarControlsPlugin(),
+  createScrollControllerPlugin(),
+  createEventsServicePlugin(),
+  createCurrentTimePlugin(),
+  createEventModalPlugin(),
+  createEventRecurrencePlugin(),
+  createResizePlugin(),
+])
 calendar.render(calendarElement)
 
 // const calendar2Element = document.getElementById('calendar-2') as HTMLElement
@@ -377,54 +393,40 @@ setViewButton.addEventListener('click', () => {
 })
 
 const setFirstDayOfWeekButton = document.getElementById(
-  'set-first-day-of-week-button'
+    'set-first-day-of-week-button'
 ) as HTMLButtonElement
 setFirstDayOfWeekButton.addEventListener('click', () => {
-  const newFirstDayOfWeek = (
-    document.getElementById('set-first-day-of-week') as HTMLInputElement
-  ).value
-  calendarControlsPlugin.setFirstDayOfWeek(
-    parseInt(newFirstDayOfWeek, 10) as WeekDay
-  )
+  const newFirstDayOfWeek = (document.getElementById('set-first-day-of-week') as HTMLInputElement)
+      .value
+  calendarControlsPlugin.setFirstDayOfWeek(parseInt(newFirstDayOfWeek, 10) as WeekDay)
 })
 
 const setNDaysButton = document.getElementById(
-  'set-n-days-button'
+    'set-n-days-button'
 ) as HTMLButtonElement
 setNDaysButton.addEventListener('click', () => {
   const newNDays = (document.getElementById('set-n-days') as HTMLInputElement)
-    .value as unknown as number
-  calendarControlsPlugin.setWeekOptions({
-    ...calendarControlsPlugin.getWeekOptions(),
-    nDays: newNDays,
-  })
+      .value as unknown as number
+  calendarControlsPlugin.setWeekOptions({...calendarControlsPlugin.getWeekOptions(), nDays: newNDays})
 })
 
 const setLocaleSelect = document.getElementById(
-  'set-locale'
+    'set-locale'
 ) as HTMLSelectElement
 setLocaleSelect.addEventListener('change', () => {
-  const newLocale = (document.getElementById('set-locale') as HTMLSelectElement)
-    .value
+  const newLocale = (document.getElementById('set-locale') as HTMLSelectElement).value
   calendarControlsPlugin.setLocale(newLocale)
 })
 
 const setDayBoundariesButton = document.getElementById(
-  'set-day-boundaries-button'
+    'set-day-boundaries-button'
 ) as HTMLButtonElement
 
 setDayBoundariesButton.addEventListener('click', () => {
-  const newDayBoundariesStart = (
-    document.getElementById('set-day-boundaries-start') as HTMLInputElement
-  ).value
-  const newDayBoundariesEnd = (
-    document.getElementById('set-day-boundaries-end') as HTMLInputElement
-  ).value
+  const newDayBoundariesStart = (document.getElementById('set-day-boundaries-start') as HTMLInputElement).value
+  const newDayBoundariesEnd = (document.getElementById('set-day-boundaries-end') as HTMLInputElement).value
 
-  calendarControlsPlugin.setDayBoundaries({
-    start: `${newDayBoundariesStart.padStart(2, '0')}:00`,
-    end: `${newDayBoundariesEnd.padStart(2, '0')}:00`,
-  })
+  calendarControlsPlugin.setDayBoundaries({start: `${newDayBoundariesStart.padStart(2, '0')}:00`, end: `${newDayBoundariesEnd.padStart(2, '0')}:00`})
 })
 
 const updateCalendarsButton = document.getElementById(
@@ -474,6 +476,6 @@ updateBackgroundEventsButton.addEventListener('click', () => {
         backgroundColor: '#f9501c',
         opacity: 0.5,
       },
-    },
+    }
   ])
 })

--- a/packages/calendar/src/components/week-grid/background-event.tsx
+++ b/packages/calendar/src/components/week-grid/background-event.tsx
@@ -30,20 +30,14 @@ export default function TimeGridBackgroundEvent({
   if (dateFromDateTime(start) !== date) start = date + ' ' + start.split(' ')[1]
   if (dateFromDateTime(end) !== date) end = date + ' ' + end.split(' ')[1]
 
-  // clamp the start and end times to the day boundaries
-  // otherwise the background event `top` and `height` is calculated incorrectly
+  // adjust the start time according to the day boundaries
+  // otherwise the background event `top` is calculated incorrectly
   const startTimePoints = timePointsFromString(start.split(' ')[1])
   if (startTimePoints < $app.config.dayBoundaries.value.start) {
     start =
       date +
       ' ' +
       timeStringFromTimePoints($app.config.dayBoundaries.value.start)
-  }
-
-  const endTimePoints = timePointsFromString(end.split(' ')[1])
-  if (endTimePoints > $app.config.dayBoundaries.value.end) {
-    end =
-      date + ' ' + timeStringFromTimePoints($app.config.dayBoundaries.value.end)
   }
 
   return (

--- a/packages/calendar/src/components/week-grid/background-event.tsx
+++ b/packages/calendar/src/components/week-grid/background-event.tsx
@@ -5,6 +5,10 @@ import { AppContext } from '../../utils/stateful/app-context'
 import { useContext } from 'preact/hooks'
 import { getYCoordinateInTimeGrid } from '@schedule-x/shared/src/utils/stateless/calendar/get-y-coordinate-in-time-grid'
 import { getEventHeight } from '../../utils/stateless/events/event-styles'
+import {
+  timePointsFromString,
+  timeStringFromTimePoints,
+} from '@schedule-x/shared/src/utils/stateless/time/time-points/string-conversion'
 
 type props = {
   backgroundEvent: BackgroundEvent
@@ -25,6 +29,22 @@ export default function TimeGridBackgroundEvent({
   // this date or end after. Nonetheless, it should appear as an event from 00:00 to 23:59 on this date in that case, and thus the start- and end-dates might have to be adjusted.
   if (dateFromDateTime(start) !== date) start = date + ' ' + start.split(' ')[1]
   if (dateFromDateTime(end) !== date) end = date + ' ' + end.split(' ')[1]
+
+  // clamp the start and end times to the day boundaries
+  // otherwise the background event `top` and `height` is calculated incorrectly
+  const startTimePoints = timePointsFromString(start.split(' ')[1])
+  if (startTimePoints < $app.config.dayBoundaries.value.start) {
+    start =
+      date +
+      ' ' +
+      timeStringFromTimePoints($app.config.dayBoundaries.value.start)
+  }
+
+  const endTimePoints = timePointsFromString(end.split(' ')[1])
+  if (endTimePoints > $app.config.dayBoundaries.value.end) {
+    end =
+      date + ' ' + timeStringFromTimePoints($app.config.dayBoundaries.value.end)
+  }
 
   return (
     <>


### PR DESCRIPTION
closes #827 

all 999 (nice) unit tests pass and desired functionality described in #827 works. Tested on chrome and firefox.

having a combination of `backgroundEvents` and `dayBoundaries` now works as expected (see gray bars at the start and end of days, these are background events, showing "out of office" hours):

![image](https://github.com/user-attachments/assets/000e60af-bd36-48bb-88ca-3b1d5b890b4d)

this is how it looks without the fix - the starts of `backgroundEvents` are not rendered correctly (see missing gray bars at the top of each day, and completely missing full day gray bars at the weekend)

![image](https://github.com/user-attachments/assets/ab251652-3d35-4c5f-94e5-4c6aeff46762)

the reason this happened was because `getYCoordinateInTimeGrid()` and `getEventHeight()` functions used `backgroundEvent.start` and `backgroundEvent.end` times. Whereas when `dayBoundaries` are used, we should use start/end of the dayBoundary and not of the backgroundEvent.

as i'm very fresh to the codebase, something might have been missed!