### PR TITLE
chore(): export PluginBase type from `@schedule-x/calendar` package

### DIFF
--- a/packages/calendar/src/calendar.app.ts
+++ b/packages/calendar/src/calendar.app.ts
@@ -6,6 +6,7 @@ import EventsFacadeImpl from '@schedule-x/shared/src/utils/stateful/events-facad
 import { CustomComponentFn } from '@schedule-x/shared/src/interfaces/calendar/calendar-config'
 import { CustomComponentFns } from '@schedule-x/shared/src/interfaces/calendar/custom-component-fns'
 import { invokePluginsBeforeRender } from './utils/stateless/plugins-lifecycle'
+import { PluginBase } from '@schedule-x/shared/src'
 
 export default class CalendarApp {
   public events: EventsFacade

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -18,6 +18,7 @@ import {
   toTimeString,
   toDateTimeString,
   toJSDate,
+  PluginBase,
 } from '@schedule-x/shared/src'
 import CalendarApp from './calendar.app'
 import { createPreactView } from './utils/stateful/preact-view/preact-view'
@@ -37,6 +38,7 @@ export type {
   DayBoundariesExternal,
   WeekOptions,
   MonthGridOptions,
+  PluginBase,
 }
 
 export {


### PR DESCRIPTION
I fell into a rabbit hole, join me for a story!

In my project i'm using Deno with Fresh framework. `@schedule-x` works just fine, but when i run `deno check` (similar to typechecking with `tsc --noEmit`), i'm getting an error:

```
error: Module not found "https://esm.sh/v135/@schedule-x/preact@2.8.0/dist/types/schedule-x-calendar.tsx".
```

i'm using esm.sh but it's irrelevant here.

The module is indeed missing! At the time of writing this, [this esm.sh link](https://esm.sh/v135/@schedule-x/preact@2.8.0/dist/types/schedule-x-calendar.tsx) shows `Module not found`.

Why tho?

`package.json` says that `"types": "dist/types/index.d.ts`, so i'm looking at that file:

```
export { ScheduleXCalendar } from './schedule-x-calendar.tsx';
export { useCalendarApp } from './use-calendar-app.tsx';
```

huh, the `.tsx` extension is a bit strange within a `.d.ts` file. Let's
see how the file is created.

Me, the consumer of this package, i get the file from a released `@schedule-x/preact` tarball. The tarball is built with a github action, which eventually runs `npm run build` which is `vite build && npm run build:dts`

ok, what da `npm run build:dts` do? it runs `node scripts/build-declarations.mjs`, which is:

https://github.com/schedule-x/preact/blob/main/scripts/build-declarations.mjs

bit weird, we're running node to run `tsc` and some shell and `content.replace`. And it's all in `try/catch` but within `catch` it just logs some output, but doesn't actually fail. Strange, but i don't know the history and i don't care. What i care is if it works or not.

so i check recent github action runs and here i see an error:

https://github.com/schedule-x/preact/actions/runs/12253666418/job/34182889290#step:5:25

since the script failed on running shell, the output is a buffer. Ok i
clone and setup the repo locally to see wtf. I get the same error, but
now i can `.toString()` it and i see:

```
src/use-calendar-app.tsx:4:17 - error TS4058: Return type of exported function has or is using name 'PluginBase' from external module "/schedule-x/preact/node_modules/@schedule-x/calendar/dist/core" but cannot be named.

4 export function useCalendarApp(config: CalendarConfig) {
                  ~~~~~~~~~~~~~~


Found 1 error in src/use-calendar-app.tsx:4
```

ugh, this is annoying error, i never know what this means. gotta go deeper. I google around and find that
this error often happens due to a missing export.

so i go to `node_modules` and just manually export the missing type. And voila it works!

awesome, let's make a PR! You're reading it! :grin:

To be honest i'm not 100% sure if this is a proper fix, but it seems
harmless, we're only adding extra export of a type (non-runtime code).
