### PR TITLE
chore(calendar): skip rendering background event when start and end datetimes are equal

### DIFF
--- a/packages/calendar/src/components/week-grid/__test__/time-grid-day/time-grid-day.spec.tsx
+++ b/packages/calendar/src/components/week-grid/__test__/time-grid-day/time-grid-day.spec.tsx
@@ -209,5 +209,26 @@ describe('TimeGridDay', () => {
           ?.attributes.getNamedItem('style')?.value
       ).toContain('height: 99.93055555555557%')
     })
+
+    it('does not render a background event, if the background event ends on the start time of the day', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: '2023-09-11',
+        dayBoundaries: {
+          start: '06:00',
+          end: '23:00',
+        },
+      })
+      renderComponent($app, [], '2023-09-11', [
+        {
+          start: '2023-09-11 05:00',
+          end: '2023-09-11 06:00',
+          style: {},
+        },
+      ])
+
+      expect(
+        document.querySelector('.sx__time-grid-background-event')
+      ).toBeNull()
+    })
   })
 })

--- a/packages/calendar/src/components/week-grid/background-event.tsx
+++ b/packages/calendar/src/components/week-grid/background-event.tsx
@@ -40,6 +40,13 @@ export default function TimeGridBackgroundEvent({
       timeStringFromTimePoints($app.config.dayBoundaries.value.start)
   }
 
+  // when start and end datetimes are equal, the rendering of the background event can be skipped completely.
+  // otherwise, `height` is calculated as 5% (by `getEventHeight`) and this is misleading for a background event like "out-of-office" hours.
+  // This comparison is safe also for full-day background events, because earlier in code we add time (00:00 - 23:59) to full-day events, making start and end no longer equal in full-day event case.
+  if (start === end) {
+    return null
+  }
+
   return (
     <>
       <div


### PR DESCRIPTION
Thanks for merging and releasing #828 so switfly! I continue to test and noticed a thingy.

consider calendar config:
```
    dayBoundaries: {
      start: '08:00',
      end: '18:00',
    },
    backgroundEvents: [
      {
        start: '2024-12-16 00:00',
        end: '2024-12-16 08:00',
        title: 'OOO',
        style: {
          background: '#272c332b',
        },
      },
    ]
```

here we have day boundaries set so that day starts at 800.
we also have one background event, which ends at 800.

because of day boundary, the background event shouldn't be visible at all, because it's timespan begins before day boundary.

however, later in code the height for background event div is calculated
by `getEventHeight()`. And it has this condition:

```
  if (start === end) {
    return (
      timePointToPercentage(
        pointsPerDay,
        dayBoundaries,
        timePointsFromString(timeFromDateTime(addTimePointsToDateTime(end, 50)))
      ) -
      timePointToPercentage(
        pointsPerDay,
        dayBoundaries,
        timePointsFromString(timeFromDateTime(start))
      )
    )
  }
```

there's that little `addTimePointsToDateTime(end, 50)`, which makes the
background event visible, even though it shouldn't be.

this addition makes sense to regular events, because they (usually) have
title, time and duration and otherwise need to be visible to the user.

but for background events adding those `50` points is misleading for the user.

Consider my example above, if i mark my out-of-office hours 00:00 -
08:00, but calendar show it as 00:00 - 08:30 (or something), it's
incorrect for the user!

so, at first i thought to improve the `getEventHeight` function by
telling it what kind of event it's dealing with, but a simpler way is to
just not render background event at all, if it's timespan is before day
boundary.

here's a visual comparison. first screenshot before this PR:

![image](https://github.com/user-attachments/assets/e3444e40-6062-42d5-97e8-f6ec4357e55f)

and after:

![image](https://github.com/user-attachments/assets/96ce917f-1557-4548-81b5-7ea5d8746351)

this calendar has various background events (different OOO hours), and day boundaries set to 08:00 - 18:00

in first screenshot notice how monday, tuesday, wednesday and friday have a little background event at the start of day. it looks like it shows background event from 08:00 to 08:30, but that's incorrect!

second screenshot has the fix applied and those little background events aren't shown anymore.
