### PR TITLE
chore(deps): import `JSX` type from `preact` instead of `preact/src/jsx`

### DIFF
--- a/packages/shared/src/interfaces/event-modal/event-modal.plugin.ts
+++ b/packages/shared/src/interfaces/event-modal/event-modal.plugin.ts
@@ -1,5 +1,5 @@
 import PluginBase from '../plugin.interface'
-import { JSXInternal } from 'preact/src/jsx'
+import { JSX } from 'preact'
 import { CalendarEventInternal } from '../calendar/calendar-event.interface'
 import CalendarAppSingleton from '../calendar/calendar-app-singleton'
 import { Signal } from '@preact/signals'
@@ -20,5 +20,5 @@ export default interface EventModalPlugin extends PluginBase<string> {
     eventTargetDOMRect: DOMRect | null
   ): void
 
-  ComponentFn(props: EventModalProps): JSXInternal.Element
+  ComponentFn(props: EventModalProps): JSX.Element
 }

--- a/packages/shared/src/types/calendar/preact-view-component.ts
+++ b/packages/shared/src/types/calendar/preact-view-component.ts
@@ -1,7 +1,7 @@
-import { JSXInternal } from 'preact/src/jsx'
+import { JSX } from 'preact'
 import CalendarAppSingleton from '../../interfaces/calendar/calendar-app-singleton'
 
 export type PreactViewComponent = (props: {
   $app: CalendarAppSingleton
   id: string
-}) => JSXInternal.Element
+}) => JSX.Element


### PR DESCRIPTION
the `package.json` of `preact` does not specify `src/jsx` within the `exports` property. therefore, doing `import { JSXInternal } from 'preact/src/jsx'` does not work in environments that use the `exports` field.

it works fine when `node_modules` are available in the project and import path can be resolved by means of traversing the file system. but for consumers of schedule-x using esm.sh or yarn with pnp enabled the import path is not resolved, because for those package managers `preact/src/jsx` is not available.

example of esm.sh error:

```
error: Module not found "https://esm.sh/preact@10.23.1/src/jsx".
    at https://esm.sh/v135/@schedule-x/calendar@2.12.0/X-ZS9AcHJlYWN0L3NpZ25hbHMsQHByZWFjdC9zaWduYWxzLWNvcmUscHJlYWN0/dist/core.d.ts:2:29
```

this commits changes the import to `import { JSX } from 'preact'`. Internally, `preact` package re-exports the same `JSXInternal` type, so it's the same thing, but now imported more correctly ([source](https://github.com/preactjs/preact/blob/main/src/index.d.ts#L5))
