### PR TITLE
chore(calendar): add `type="button"` to all buttons

### DIFF
--- a/packages/calendar/src/components/header/today-button.tsx
+++ b/packages/calendar/src/components/header/today-button.tsx
@@ -10,7 +10,11 @@ export default function TodayButton() {
   }
 
   return (
-    <button className={'sx__today-button sx__ripple'} onClick={setToday}>
+    <button
+      type="button"
+      className={'sx__today-button sx__ripple'}
+      onClick={setToday}
+    >
       {$app.translate('Today')}
     </button>
   )

--- a/packages/calendar/src/views/month-agenda/components/month-agenda-day.tsx
+++ b/packages/calendar/src/views/month-agenda/components/month-agenda-day.tsx
@@ -70,6 +70,7 @@ export default function MonthAgendaDay({
   )
   return (
     <button
+      type="button"
       className={dayClasses.join(' ')}
       onClick={(e) => handleClick(e, $app.config.callbacks.onClickAgendaDate)}
       onDblClick={(e) =>

--- a/packages/calendar/src/views/month-grid/components/month-grid-day.tsx
+++ b/packages/calendar/src/views/month-grid/components/month-grid-day.tsx
@@ -173,6 +173,7 @@ export default function MonthGridDay({ day, isFirstWeek, isLastWeek }: props) {
 
       {numberOfNonDisplayedEvents > 0 ? (
         <button
+          type="button"
           className="sx__month-grid-day__events-more sx__ripple--wide"
           aria-label={getAriaLabelSingularOrPlural(numberOfNonDisplayedEvents)}
           onClick={handleClickAdditionalEvents}

--- a/packages/date-picker/src/components/app-input.tsx
+++ b/packages/date-picker/src/components/app-input.tsx
@@ -106,6 +106,7 @@ export default function AppInput() {
         />
 
         <button
+          type="button"
           tabIndex={$app.datePickerState.isDisabled.value ? -1 : 0}
           aria-label={$app.translate('Choose Date')}
           onKeyDown={handleButtonKeyDown}

--- a/packages/date-picker/src/components/month-view-header.tsx
+++ b/packages/date-picker/src/components/month-view-header.tsx
@@ -68,6 +68,7 @@ export default function MonthViewHeader({ setYearsView }: props) {
         />
 
         <button
+          type="button"
           className="sx__date-picker__month-view-header__month-year"
           onClick={(event) => handleOpenYearsView(event)}
         >

--- a/packages/date-picker/src/components/month-view-week.tsx
+++ b/packages/date-picker/src/components/month-view-week.tsx
@@ -76,6 +76,7 @@ export default function MonthViewWeek({ week }: props) {
       <div data-testid={DATE_PICKER_WEEK} className="sx__date-picker__week">
         {weekDays.map((weekDay) => (
           <button
+            type="button"
             tabIndex={hasFocus(weekDay) ? 0 : -1}
             disabled={!isDateSelectable(weekDay.day)}
             aria-label={getLocalizedDate(

--- a/packages/date-picker/src/components/years-view-accordion.tsx
+++ b/packages/date-picker/src/components/years-view-accordion.tsx
@@ -28,6 +28,7 @@ export default function YearsViewAccordion({
     <>
       <li className={isExpanded ? 'sx__is-expanded' : ''}>
         <button
+          type="button"
           className="sx__date-picker__years-accordion__expand-button sx__ripple--wide"
           onClick={() => expand(year)}
         >
@@ -37,6 +38,7 @@ export default function YearsViewAccordion({
           <div className="sx__date-picker__years-view-accordion__panel">
             {yearWithDates.map((month) => (
               <button
+                type="button"
                 className="sx__date-picker__years-view-accordion__month"
                 onClick={(event) => handleClickOnMonth(event, month)}
               >

--- a/packages/shared/src/components/buttons/chevron.tsx
+++ b/packages/shared/src/components/buttons/chevron.tsx
@@ -19,6 +19,7 @@ export default function Chevron({
 
   return (
     <button
+      type="button"
       disabled={disabled}
       className="sx__chevron-wrapper sx__ripple"
       onMouseUp={onClick}

--- a/packages/time-picker/src/components/app-popup.tsx
+++ b/packages/time-picker/src/components/app-popup.tsx
@@ -162,6 +162,7 @@ export default function AppPopup() {
         {$app.config.is12Hour.value && (
           <div className="sx__time-picker-12-hour-switches">
             <button
+              type="button"
               className={`sx__time-picker-12-hour-switch${$app.timePickerState.isAM.value ? ' is-selected' : ''}`}
               onClick={() => ($app.timePickerState.isAM.value = true)}
             >
@@ -169,6 +170,7 @@ export default function AppPopup() {
             </button>
 
             <button
+              type="button"
               className={`sx__time-picker-12-hour-switch${!$app.timePickerState.isAM.value ? ' is-selected' : ''}`}
               onClick={() => ($app.timePickerState.isAM.value = false)}
             >
@@ -180,6 +182,7 @@ export default function AppPopup() {
 
       <div class="sx__time-picker-actions">
         <button
+          type="button"
           class="sx__time-picker-action sx__ripple sx__button-cancel"
           onClick={() => ($app.timePickerState.isOpen.value = false)}
         >
@@ -188,6 +191,7 @@ export default function AppPopup() {
 
         <button
           ref={OKButtonRef}
+          type="button"
           class="sx__time-picker-action sx__ripple sx__button-accept"
           onClick={handleAccept}
         >


### PR DESCRIPTION
if user of schedule-x is rendering the calendar within a `<form>` tag, then any of the calendar buttons become submit buttons by default.

A `<form><button>i submit</button></form>` is same as `<form><button type="submit">i submit</button></form>`.

this is a problem because the calendar buttons are not meant to submit, for example the "Today" button is for changing the calendar view to the current day. Currently if calendar is rendered within a form, clicking the "Today" button will submit the form, which is unexpected for the user.

Explicitly setting `type="button"` on all buttons within the calendar components prevents this issue.

Although in some cases there is `event.preventDefault()` in the button click handler, it's still worth setting `type="button"` to prevent form submission (say if JS hasn't loaded yet, or if `event.preventDefault()` is missed/removed.