### PR TITLE
Add support for premium calendar options

### DIFF
--- a/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.builder.ts
@@ -28,6 +28,7 @@ import {
 import { InternalViewName } from '@schedule-x/shared/src/enums/calendar/internal-view.enum'
 import { BackgroundEvent } from '@schedule-x/shared/src/interfaces/calendar/background-event'
 import { Language } from '@schedule-x/shared/src/types/translations/language.translations'
+import { PremiumOptionsInternal } from '@schedule-x/shared/src/types/premium/PremiumOptions'
 
 export default class CalendarConfigBuilder
   implements Builder<CalendarConfigInternal>
@@ -56,6 +57,7 @@ export default class CalendarConfigBuilder
   theme: string | undefined
   //TODO:Change for V3
   translations: Record<string, Language> | undefined
+  premiumOptions: PremiumOptionsInternal | undefined
 
   build(): CalendarConfigInternal {
     return new CalendarConfigImpl(
@@ -77,7 +79,8 @@ export default class CalendarConfigBuilder
       this.maxDate,
       this.monthGridOptions,
       this.theme,
-      this.translations
+      this.translations,
+      this.premiumOptions
     )
   }
 

--- a/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
+++ b/packages/calendar/src/utils/stateful/config/calendar-config.impl.ts
@@ -16,6 +16,11 @@ import { DEFAULT_DAY_BOUNDARIES } from '../../../constants'
 import { timePointsPerDay } from '@schedule-x/shared/src/utils/stateless/time/time-points/time-points-per-day'
 import { Signal, signal } from '@preact/signals'
 import { Language } from '@schedule-x/shared/src/types/translations/language.translations'
+import {
+  PremiumOptionsExternal,
+  PremiumOptionsInternal,
+} from '@schedule-x/shared/src/types/premium/PremiumOptions'
+import { Default_PremiumOptions } from '@schedule-x/shared/src/values/premium-options'
 
 export default class CalendarConfigImpl implements CalendarConfigInternal {
   firstDayOfWeek: Signal<WeekDay>
@@ -30,6 +35,7 @@ export default class CalendarConfigImpl implements CalendarConfigInternal {
   locale: Signal<string> = signal(DEFAULT_LOCALE)
   theme: string | undefined
   translations: Signal<Record<string, Language>>
+  premiumOptions: Signal<PremiumOptionsInternal>
 
   constructor(
     locale: string = DEFAULT_LOCALE,
@@ -50,7 +56,8 @@ export default class CalendarConfigImpl implements CalendarConfigInternal {
       nEventsPerDay: 4,
     },
     theme: string | undefined = undefined,
-    translations: Record<string, Language> = {}
+    translations: Record<string, Language> = {},
+    premium: PremiumOptionsExternal = Default_PremiumOptions
   ) {
     this.locale = signal(locale)
     this.firstDayOfWeek = signal(firstDayOfWeek)
@@ -64,6 +71,7 @@ export default class CalendarConfigImpl implements CalendarConfigInternal {
     this.monthGridOptions = signal(monthGridOptions)
     this.theme = theme
     this.translations = signal(translations)
+    this.premiumOptions = signal(premium)
   }
 
   get isHybridDay(): boolean {

--- a/packages/shared/src/interfaces/calendar/calendar-config.ts
+++ b/packages/shared/src/interfaces/calendar/calendar-config.ts
@@ -18,6 +18,10 @@ import { Signal } from '@preact/signals'
 import { WeekDay } from '../../enums/time/week-day.enum'
 import { BackgroundEvent } from './background-event'
 import { Language } from '../../types/translations/language.translations'
+import {
+  PremiumOptionsExternal,
+  PremiumOptionsInternal,
+} from '../../types/premium/PremiumOptions'
 
 export type WeekOptions = {
   gridHeight: number
@@ -74,6 +78,7 @@ export default interface CalendarConfigInternal extends Config {
   _customComponentFns: CustomComponentFns
   translations: Signal<Record<string, Language>>
 
+  premiumOptions: Signal<PremiumOptionsInternal>
   // Getters
   isHybridDay: boolean
   timePointsPerDay: number
@@ -100,6 +105,7 @@ interface ReducedCalendarConfigInternal
     | 'locale'
     | 'firstDayOfWeek'
     | 'translations'
+    | 'Premium'
   > {}
 
 export interface CalendarConfigExternal
@@ -121,4 +127,5 @@ export interface CalendarConfigExternal
   firstDayOfWeek?: WeekDay
   skipValidation?: boolean
   translations?: Record<string, Language>
+  premium?: PremiumOptionsExternal
 }

--- a/packages/shared/src/types/premium/PremiumOptions.ts
+++ b/packages/shared/src/types/premium/PremiumOptions.ts
@@ -1,0 +1,9 @@
+export type PremiumOptionsExternal = {
+  DragAndDrop: boolean
+  Resize: boolean
+}
+
+export type PremiumOptionsInternal = {
+  DragAndDrop: boolean
+  Resize: boolean
+}

--- a/packages/shared/src/values/premium-options.ts
+++ b/packages/shared/src/values/premium-options.ts
@@ -1,0 +1,4 @@
+export const Default_PremiumOptions = {
+  DragAndDrop: true,
+  Resize: true,
+}


### PR DESCRIPTION
Integrated premium configuration into the calendar with options for drag-and-drop and resize functionalities. Defined default premium options and updated relevant builders, interfaces, and implementations to handle these configurations.

## Checklist

Please put "X" in the below checkboxes that apply:

- [X ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [ ] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

First Step to disable Drag and Drop in Premium


