### PR TITLE
feat(calendar): add uievent to onEventClick and onEventDoubleClick callback

### DIFF
--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -156,12 +156,12 @@ const calendar = createCalendar({
       console.log('onEventUpdate', event)
     },
 
-    onEventClick(event) {
-      console.log('onEventClick', event)
+    onEventClick(event, e) {
+      console.log('onEventClick', event, e)
     },
 
-    onDoubleClickEvent(event) {
-      console.log('onDoubleClickEvent', event)
+    onDoubleClickEvent(event, e) {
+      console.log('onDoubleClickEvent', event, e)
     },
 
     onClickDate(date) {

--- a/packages/calendar/src/components/__test__/callbacks.spec.tsx
+++ b/packages/calendar/src/components/__test__/callbacks.spec.tsx
@@ -113,6 +113,10 @@ describe('Calendar callbacks', () => {
         end: '2023-12-01 23:59',
         title: 'Event 1',
       }
+      const uiEvent = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
       const $app = createCalendarAppSingleton({
         views: [viewMonthGrid, viewMonthAgenda, viewDay, viewWeek],
         callbacks: {
@@ -124,12 +128,12 @@ describe('Calendar callbacks', () => {
       })
       renderComponent($app)
 
-      await clickByText('Event 1')
+      await clickByText('Event 1', uiEvent)
 
       await waitFor(() => {
         expect(onEventClick).toHaveBeenCalledTimes(1)
 
-        expect(onEventClick).toHaveBeenCalledWith(calendarEvent)
+        expect(onEventClick).toHaveBeenCalledWith(calendarEvent, uiEvent)
       })
     })
 
@@ -147,6 +151,10 @@ describe('Calendar callbacks', () => {
           end: '2023-12-01 23:59',
           title: 'Event 1',
         }
+        const uiEvent = new MouseEvent('dblclick', {
+          bubbles: true,
+          cancelable: true,
+        })
         const $app = createCalendarAppSingleton({
           views: [viewMonthGrid, viewMonthAgenda, viewDay, viewWeek],
           callbacks: {
@@ -158,12 +166,15 @@ describe('Calendar callbacks', () => {
         })
         renderComponent($app)
 
-        await doubleClickByText('Event 1')
+        await doubleClickByText('Event 1', uiEvent)
 
         await waitFor(() => {
           expect(onDoubleClickEvent).toHaveBeenCalledTimes(1)
 
-          expect(onDoubleClickEvent).toHaveBeenCalledWith(calendarEvent)
+          expect(onDoubleClickEvent).toHaveBeenCalledWith(
+            calendarEvent,
+            uiEvent
+          )
         })
       })
     })

--- a/packages/calendar/src/components/week-grid/date-grid-event.tsx
+++ b/packages/calendar/src/components/week-grid/date-grid-event.tsx
@@ -107,7 +107,7 @@ export default function DateGridEvent({
     if (e.key === 'Enter' || e.key === ' ') {
       e.stopPropagation()
       setClickedEvent(e, calendarEvent)
-      invokeOnEventClickCallback($app, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent, e)
       nextTick(() => {
         focusModal($app)
       })
@@ -154,8 +154,10 @@ export default function DateGridEvent({
         onMouseUp={(e) => setClickedEventIfNotDragging(calendarEvent, e)}
         onTouchStart={(e) => createDragStartTimeout(handleStartDrag, e)}
         onTouchEnd={(e) => setClickedEventIfNotDragging(calendarEvent, e)}
-        onClick={() => invokeOnEventClickCallback($app, calendarEvent)}
-        onDblClick={() => invokeOnEventDoubleClickCallback($app, calendarEvent)}
+        onClick={(e) => invokeOnEventClickCallback($app, calendarEvent, e)}
+        onDblClick={(e) =>
+          invokeOnEventDoubleClickCallback($app, calendarEvent, e)
+        }
         onKeyDown={handleKeyDown}
         className={eventClasses.join(' ')}
         style={{

--- a/packages/calendar/src/components/week-grid/time-grid-event.tsx
+++ b/packages/calendar/src/components/week-grid/time-grid-event.tsx
@@ -114,19 +114,19 @@ export default function TimeGridEvent({
 
   const handleOnClick = (e: MouseEvent) => {
     e.stopPropagation()
-    invokeOnEventClickCallback($app, calendarEvent)
+    invokeOnEventClickCallback($app, calendarEvent, e)
   }
 
   const handleOnDoubleClick = (e: MouseEvent) => {
     e.stopPropagation()
-    invokeOnEventDoubleClickCallback($app, calendarEvent)
+    invokeOnEventDoubleClickCallback($app, calendarEvent, e)
   }
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.stopPropagation()
       setClickedEvent(e, calendarEvent)
-      invokeOnEventClickCallback($app, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent, e)
       nextTick(() => {
         focusModal($app)
       })

--- a/packages/calendar/src/utils/stateless/events/invoke-on-event-click-callback.ts
+++ b/packages/calendar/src/utils/stateless/events/invoke-on-event-click-callback.ts
@@ -3,9 +3,10 @@ import { CalendarEventInternal } from '@schedule-x/shared/src/interfaces/calenda
 
 export const invokeOnEventClickCallback = (
   $app: CalendarAppSingleton,
-  calendarEvent: CalendarEventInternal
+  calendarEvent: CalendarEventInternal,
+  e: UIEvent
 ) => {
   if ($app.config.callbacks.onEventClick) {
-    $app.config.callbacks.onEventClick(calendarEvent._getExternalEvent())
+    $app.config.callbacks.onEventClick(calendarEvent._getExternalEvent(), e)
   }
 }

--- a/packages/calendar/src/utils/stateless/events/invoke-on-event-double-click-callback.ts
+++ b/packages/calendar/src/utils/stateless/events/invoke-on-event-double-click-callback.ts
@@ -3,9 +3,13 @@ import { CalendarEventInternal } from '@schedule-x/shared/src/interfaces/calenda
 
 export const invokeOnEventDoubleClickCallback = (
   $app: CalendarAppSingleton,
-  calendarEvent: CalendarEventInternal
+  calendarEvent: CalendarEventInternal,
+  e: UIEvent
 ) => {
   if ($app.config.callbacks.onDoubleClickEvent) {
-    $app.config.callbacks.onDoubleClickEvent(calendarEvent._getExternalEvent())
+    $app.config.callbacks.onDoubleClickEvent(
+      calendarEvent._getExternalEvent(),
+      e
+    )
   }
 }

--- a/packages/calendar/src/utils/stateless/testing/click-by-text.ts
+++ b/packages/calendar/src/utils/stateless/testing/click-by-text.ts
@@ -1,18 +1,22 @@
 import { screen, waitFor, fireEvent } from '@testing-library/preact'
-export const clickByText = async (text: string) => {
-  await waitFor(() => {
-    screen.getByText(text).click()
-  })
-}
-
-export const doubleClickByText = async (text: string) => {
+export const clickByText = async (text: string, event?: MouseEvent) => {
   await waitFor(() => {
     fireEvent(
       screen.getByText(text),
-      new MouseEvent('dblclick', {
-        bubbles: true,
-        cancelable: true,
-      })
+      event || new MouseEvent('click', { bubbles: true, cancelable: true })
+    )
+  })
+}
+
+export const doubleClickByText = async (text: string, event?: MouseEvent) => {
+  await waitFor(() => {
+    fireEvent(
+      screen.getByText(text),
+      event ||
+        new MouseEvent('dblclick', {
+          bubbles: true,
+          cancelable: true,
+        })
     )
   })
 }

--- a/packages/calendar/src/views/month-agenda/components/month-agenda-event.tsx
+++ b/packages/calendar/src/views/month-agenda/components/month-agenda-event.tsx
@@ -40,19 +40,19 @@ export default function MonthAgendaEvent({ calendarEvent }: props) {
 
   const onClick = (e: MouseEvent) => {
     setClickedEvent(e, calendarEvent)
-    invokeOnEventClickCallback($app, calendarEvent)
+    invokeOnEventClickCallback($app, calendarEvent, e)
   }
 
   const onDoubleClick = (e: MouseEvent) => {
     setClickedEvent(e, calendarEvent)
-    invokeOnEventDoubleClickCallback($app, calendarEvent)
+    invokeOnEventDoubleClickCallback($app, calendarEvent, e)
   }
 
   const onKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.stopPropagation()
       setClickedEvent(e, calendarEvent)
-      invokeOnEventClickCallback($app, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent, e)
       nextTick(() => {
         focusModal($app)
       })

--- a/packages/calendar/src/views/month-grid/components/month-grid-event.tsx
+++ b/packages/calendar/src/views/month-grid/components/month-grid-event.tsx
@@ -88,19 +88,19 @@ export default function MonthGridEvent({
 
   const handleOnClick = (e: MouseEvent) => {
     e.stopPropagation() // prevent the click from bubbling up to the day element
-    invokeOnEventClickCallback($app, calendarEvent)
+    invokeOnEventClickCallback($app, calendarEvent, e)
   }
 
   const handleOnDoubleClick = (e: MouseEvent) => {
     e.stopPropagation() // prevent the click from bubbling up to the day element
-    invokeOnEventDoubleClickCallback($app, calendarEvent)
+    invokeOnEventDoubleClickCallback($app, calendarEvent, e)
   }
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.stopPropagation()
       setClickedEvent(e, calendarEvent)
-      invokeOnEventClickCallback($app, calendarEvent)
+      invokeOnEventClickCallback($app, calendarEvent, e)
       nextTick(() => {
         focusModal($app)
       })

--- a/packages/shared/src/interfaces/calendar/listeners.interface.ts
+++ b/packages/shared/src/interfaces/calendar/listeners.interface.ts
@@ -3,8 +3,8 @@ import { DateRange } from '../../types/date-range'
 import CalendarAppSingleton from './calendar-app-singleton'
 
 export interface CalendarCallbacks {
-  onEventClick?: (event: CalendarEventExternal) => void
-  onDoubleClickEvent?: (event: CalendarEventExternal) => void
+  onEventClick?: (event: CalendarEventExternal, e: UIEvent) => void
+  onDoubleClickEvent?: (event: CalendarEventExternal, e: UIEvent) => void
   onRangeUpdate?: (range: DateRange) => void
   onSelectedDateUpdate?: (date: string) => void
   onClickDate?: (date: string) => void


### PR DESCRIPTION
I've added the DOM event to both onEventClick and onEventDoubleClick callback and adjusted the tests accordingly to the changes. I would say that adding the event for all other possible callbacks would be interesting too.

## This PR solves the following problem. 

Closes https://github.com/schedule-x/schedule-x/issues/863. Now we have access to the target element. 🥳

## How to test this PR. 

A `console.log` in the edited callbacks is enough to test it.