### PR TITLE
chore: add croatian (hr-HR) translations

### DIFF
--- a/development/calendar/main.tsx
+++ b/development/calendar/main.tsx
@@ -79,7 +79,7 @@ const calendar = createCalendar({
   //   nEventsPerDay: 7
   // },
   firstDayOfWeek: 1,
-   // locale: 'de-BL',
+  // locale: 'de-BL',
   // locale: 'pt-BR',
   // locale: 'en-US',
   // locale: 'zh-CN',
@@ -87,6 +87,7 @@ const calendar = createCalendar({
   //locale: 'zh-TW',
   // locale: 'et-EE',
   // locale: 'ca-ES',
+  // locale: 'hr-HR',
   views: [createViewMonthGrid(), createViewWeek(), createViewDay(), createViewMonthAgenda()],
   // defaultView: viewWeek.name,
   // minDate: '2024-01-01',

--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -55,6 +55,8 @@ import { srRS } from './locales/sr-RS'
 import { datePickerSrRS } from './locales/sr-RS/date-picker'
 import { ltLT } from './locales/lt-LT'
 import { datePickerLtLT } from './locales/lt-LT/date-picker'
+import  {hrHr } from "./locales/hr-HR"
+import { datePickerHrHR } from "./locales/hr-HR/date-picker"
 
 import { translate } from './translator/translate'
 
@@ -87,6 +89,7 @@ const translations = {
   srLatnRS,
   srRS,
   ltLT,
+  hrHr
 }
 
 const datePickerTranslations = {
@@ -118,6 +121,7 @@ const datePickerTranslations = {
   srLatnRS: datePickerSrLatnRS,
   srRS: datePickerSrRS,
   ltLT: datePickerLtLT,
+  hrHr: datePickerHrHR
 }
 
 export {
@@ -151,4 +155,5 @@ export {
   caES,
   srLatnRS,
   ltLT,
+  hrHr
 }

--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -55,8 +55,8 @@ import { srRS } from './locales/sr-RS'
 import { datePickerSrRS } from './locales/sr-RS/date-picker'
 import { ltLT } from './locales/lt-LT'
 import { datePickerLtLT } from './locales/lt-LT/date-picker'
-import  {hrHr } from "./locales/hr-HR"
-import { datePickerHrHR } from "./locales/hr-HR/date-picker"
+import { hrHR } from './locales/hr-HR'
+import { datePickerHrHR } from './locales/hr-HR/date-picker'
 
 import { translate } from './translator/translate'
 
@@ -89,7 +89,7 @@ const translations = {
   srLatnRS,
   srRS,
   ltLT,
-  hrHr
+  hrHR,
 }
 
 const datePickerTranslations = {
@@ -121,7 +121,7 @@ const datePickerTranslations = {
   srLatnRS: datePickerSrLatnRS,
   srRS: datePickerSrRS,
   ltLT: datePickerLtLT,
-  hrHr: datePickerHrHR
+  hrHr: datePickerHrHR,
 }
 
 export {
@@ -155,5 +155,5 @@ export {
   caES,
   srLatnRS,
   ltLT,
-  hrHr
+  hrHR,
 }

--- a/packages/translations/src/locales/hr-HR/calendar.ts
+++ b/packages/translations/src/locales/hr-HR/calendar.ts
@@ -1,0 +1,19 @@
+import { CalendarTranslations } from '@schedule-x/shared/src/types/translations/calendar.translations'
+
+export const calendarHrHR: CalendarTranslations = {
+  Today: 'Danas',
+  Month: 'Mjesec',
+  Week: 'Nedjelja',
+  Day: 'Dan',
+  'Select View': 'Odaberite pregled',
+  events: 'Događaji',
+  event: 'Događaj',
+  'No events': 'Nema događaja',
+  'Next period': 'Sljedeći period',
+  'Previous period': 'Prethodni period',
+  to: 'do', // as in 2/1/2020 to 2/2/2020
+  'Full day- and multiple day events': 'Cjelodnevni i višednevni događaji',
+  'Link to {{n}} more events on {{date}}':
+    'Link do još {{n}} događaja na {{date}}',
+  'Link to 1 more event on {{date}}': 'Link do još jednog događaja na {{date}}',
+}

--- a/packages/translations/src/locales/hr-HR/date-picker.ts
+++ b/packages/translations/src/locales/hr-HR/date-picker.ts
@@ -1,0 +1,9 @@
+import { DatePickerTranslations } from '@schedule-x/shared/src/types/translations/date-picker.translations'
+
+export const datePickerHrHR: DatePickerTranslations = {
+  Date: 'Datum',
+  'MM/DD/YYYY': 'DD/MM/YYYY',
+  'Next month': 'Sljedeći mjesec',
+  'Previous month': 'Prethodni mjesec',
+  'Choose Date': 'Izaberite datum',
+}

--- a/packages/translations/src/locales/hr-HR/index.ts
+++ b/packages/translations/src/locales/hr-HR/index.ts
@@ -1,0 +1,8 @@
+import { datePickerHrHR } from './date-picker'
+import { Language } from '@schedule-x/shared/src/types/translations/language.translations'
+import { calendarHrHR } from './calendar'
+
+export const hrHr: Language = {
+  ...datePickerHrHR,
+  ...calendarHrHR,
+}

--- a/packages/translations/src/locales/hr-HR/index.ts
+++ b/packages/translations/src/locales/hr-HR/index.ts
@@ -2,7 +2,7 @@ import { datePickerHrHR } from './date-picker'
 import { Language } from '@schedule-x/shared/src/types/translations/language.translations'
 import { calendarHrHR } from './calendar'
 
-export const hrHr: Language = {
+export const hrHR: Language = {
   ...datePickerHrHR,
   ...calendarHrHR,
 }

--- a/website/pages/docs/calendar/supported-languages.mdx
+++ b/website/pages/docs/calendar/supported-languages.mdx
@@ -38,3 +38,4 @@ your translations under the folder: `packages/translations/src/locales/xx-XX`
 | Swedish                  | sv-SE      |
 | Turkish                  | tr-TR      |
 | Ukrainian                | uk-UA      |
+| Croatian                 | hr-HR      |


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [x] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

Insert your description or reference to the issue here.

## How to test this PR**. 

For example:  
1. Change the locale to Croatian when constructing new calendar instance

```bash
const calendar = useCalendarApp({
  locale: 'hr-HR',
});
```