### PR TITLE
feat(event-recurrence): recurrence exceptions

### DIFF
--- a/packages/event-recurrence/src/event-recurrence-plugin.impl.ts
+++ b/packages/event-recurrence/src/event-recurrence-plugin.impl.ts
@@ -93,10 +93,13 @@ class EventRecurrencePluginImpl implements EventRecurrencePlugin {
 
     $app.calendarEvents.list.value.forEach((event) => {
       const rrule = event._getForeignProperties().rrule as string | undefined
+      const exdate = event._getForeignProperties().exdate as
+        | string[]
+        | undefined
 
       if (rrule) {
         recurrencesToCreate.push(
-          ...this.createRecurrencesForEvent(event, rrule)
+          ...this.createRecurrencesForEvent(event, rrule, exdate)
         )
       }
     })
@@ -129,7 +132,8 @@ class EventRecurrencePluginImpl implements EventRecurrencePlugin {
 
   private createRecurrencesForEvent(
     calendarEvent: CalendarEventInternal,
-    rrule: string
+    rrule: string,
+    exdate?: string[] | undefined
   ) {
     if (!this.range) {
       console.warn(
@@ -142,7 +146,8 @@ class EventRecurrencePluginImpl implements EventRecurrencePlugin {
       this.$app as CalendarAppSingleton,
       calendarEvent,
       rrule,
-      this.range
+      this.range,
+      exdate
     )
   }
 

--- a/packages/event-recurrence/src/util/stateful/events-facade.ts
+++ b/packages/event-recurrence/src/util/stateful/events-facade.ts
@@ -79,6 +79,8 @@ export class EventsFacadeImpl implements EventsFacade {
     const updatedEvent = externalEventToInternal(event, this.$app.config)
     const copiedEvents = [...this.$app.calendarEvents.list.value, updatedEvent]
     const rrule = (updatedEvent as AugmentedEvent)._getForeignProperties().rrule
+    const exdate = (updatedEvent as AugmentedEvent)._getForeignProperties()
+      .exdate as string[] | undefined
     if (
       rrule &&
       typeof rrule === 'string' &&
@@ -89,7 +91,8 @@ export class EventsFacadeImpl implements EventsFacade {
           this.$app,
           updatedEvent,
           rrule,
-          this.$app.calendarState.range.value
+          this.$app.calendarState.range.value,
+          exdate
         )
       )
     }

--- a/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
+++ b/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
@@ -14,7 +14,8 @@ export const createRecurrencesForEvent = (
   $app: CalendarAppSingleton,
   calendarEvent: CalendarEventInternal,
   rrule: string,
-  range: DateRange
+  range: DateRange,
+  exdate?: string[] | undefined
 ) => {
   // if there is no count or until in the rrule, set an until date to range.end but in rfc string format
   if (!rrule.includes('COUNT') && !rrule.includes('UNTIL')) {
@@ -26,6 +27,7 @@ export const createRecurrencesForEvent = (
     dtstart: parseSXToRFC5545(calendarEvent.start),
     dtend: parseSXToRFC5545(calendarEvent.end),
     rrule,
+    exdate,
   })
 
   return recurrenceSet

--- a/packages/recurrence/src/recurrence-set/__test__/get-daily-rule.spec.ts
+++ b/packages/recurrence/src/recurrence-set/__test__/get-daily-rule.spec.ts
@@ -43,91 +43,248 @@ describe('Getting daily recurrences', () => {
         },
       ])
     })
-  })
-
-  describe('Using FREQ, UNTIL and INTERVAL', () => {
-    it('should return the correct recurrences', () => {
+    it('should exclude datetimes specified in exdate', () => {
+      const exdate = ['20250504T063000', '20250508T063000']
       const rset = new RecurrenceSet({
-        rrule: 'FREQ=DAILY;UNTIL=20240212T063000;INTERVAL=2',
-        dtstart: '20240202T063000',
-        dtend: '20240202T080000',
+        rrule: 'FREQ=DAILY;COUNT=8;INTERVAL=2',
+        dtstart: '20250502T063000',
+        dtend: '20250502T080000',
+        exdate: exdate,
       })
 
       const recurrences = rset.getRecurrences()
 
       expect(recurrences).toEqual([
         {
-          start: '2024-02-02 06:30',
-          end: '2024-02-02 08:00',
+          start: '2025-05-02 06:30',
+          end: '2025-05-02 08:00',
         },
         {
-          start: '2024-02-04 06:30',
-          end: '2024-02-04 08:00',
+          start: '2025-05-06 06:30',
+          end: '2025-05-06 08:00',
         },
         {
-          start: '2024-02-06 06:30',
-          end: '2024-02-06 08:00',
+          start: '2025-05-10 06:30',
+          end: '2025-05-10 08:00',
         },
         {
-          start: '2024-02-08 06:30',
-          end: '2024-02-08 08:00',
+          start: '2025-05-12 06:30',
+          end: '2025-05-12 08:00',
         },
         {
-          start: '2024-02-10 06:30',
-          end: '2024-02-10 08:00',
+          start: '2025-05-14 06:30',
+          end: '2025-05-14 08:00',
         },
         {
-          start: '2024-02-12 06:30',
-          end: '2024-02-12 08:00',
+          start: '2025-05-16 06:30',
+          end: '2025-05-16 08:00',
         },
       ])
+
+      const excludedFormattedDates = [
+        {
+          start: '2025-05-04 06:30',
+          end: '2025-05-04 08:00',
+        },
+        {
+          start: '2025-05-08 06:30',
+          end: '2025-05-08 08:00',
+        },
+      ]
+      expect(recurrences).toEqual(
+        expect.not.arrayContaining(excludedFormattedDates)
+      )
+      expect(recurrences.length).toBe(6)
     })
-  })
 
-  describe('Using FREQ, BYDAY and INTERVAL', () => {
-    it('should return all Saturdays and Sundays in February 2024', () => {
-      const rset = new RecurrenceSet({
-        rrule: 'FREQ=WEEKLY;BYDAY=SA,SU;UNTIL=20240229',
-        dtstart: '20240203',
-        dtend: '20240203',
+    describe('Using FREQ, UNTIL and INTERVAL', () => {
+      it('should return the correct recurrences', () => {
+        const rset = new RecurrenceSet({
+          rrule: 'FREQ=DAILY;UNTIL=20240212T063000;INTERVAL=2',
+          dtstart: '20240202T063000',
+          dtend: '20240202T080000',
+        })
+
+        const recurrences = rset.getRecurrences()
+
+        expect(recurrences).toEqual([
+          {
+            start: '2024-02-02 06:30',
+            end: '2024-02-02 08:00',
+          },
+          {
+            start: '2024-02-04 06:30',
+            end: '2024-02-04 08:00',
+          },
+          {
+            start: '2024-02-06 06:30',
+            end: '2024-02-06 08:00',
+          },
+          {
+            start: '2024-02-08 06:30',
+            end: '2024-02-08 08:00',
+          },
+          {
+            start: '2024-02-10 06:30',
+            end: '2024-02-10 08:00',
+          },
+          {
+            start: '2024-02-12 06:30',
+            end: '2024-02-12 08:00',
+          },
+        ])
       })
+      it('should generate daily recurrences every 2 days excluding specified exdate', () => {
+        const exdate = ['20250508', '20250512']
 
-      const recurrences = rset.getRecurrences()
+        const rset = new RecurrenceSet({
+          rrule: 'FREQ=DAILY;UNTIL=20250520;INTERVAL=2',
+          dtstart: '20250502',
+          dtend: '20250502',
+          exdate,
+        })
 
-      expect(recurrences).toEqual([
-        {
-          start: '2024-02-03',
-          end: '2024-02-03',
-        },
-        {
-          start: '2024-02-04',
-          end: '2024-02-04',
-        },
-        {
-          start: '2024-02-10',
-          end: '2024-02-10',
-        },
-        {
-          start: '2024-02-11',
-          end: '2024-02-11',
-        },
-        {
-          start: '2024-02-17',
-          end: '2024-02-17',
-        },
-        {
-          start: '2024-02-18',
-          end: '2024-02-18',
-        },
-        {
-          start: '2024-02-24',
-          end: '2024-02-24',
-        },
-        {
-          start: '2024-02-25',
-          end: '2024-02-25',
-        },
-      ])
+        const recurrences = rset.getRecurrences()
+
+        expect(recurrences).toEqual([
+          {
+            start: '2025-05-02',
+            end: '2025-05-02',
+          },
+          {
+            start: '2025-05-04',
+            end: '2025-05-04',
+          },
+          {
+            start: '2025-05-06',
+            end: '2025-05-06',
+          },
+          {
+            start: '2025-05-10',
+            end: '2025-05-10',
+          },
+          {
+            start: '2025-05-14',
+            end: '2025-05-14',
+          },
+          {
+            start: '2025-05-16',
+            end: '2025-05-16',
+          },
+          {
+            start: '2025-05-18',
+            end: '2025-05-18',
+          },
+          {
+            start: '2025-05-20',
+            end: '2025-05-20',
+          },
+        ])
+
+        const excludedFormattedDates = [
+          {
+            start: '2025-05-08',
+            end: '2025-05-08',
+          },
+          {
+            start: '2025-05-12',
+            end: '2025-05-12',
+          },
+        ]
+
+        expect(recurrences).toEqual(
+          expect.not.arrayContaining(excludedFormattedDates)
+        )
+        expect(recurrences.length).toBe(8)
+      })
+    })
+
+    describe('Using FREQ, BYDAY and INTERVAL', () => {
+      it('should return all Saturdays and Sundays in February 2024', () => {
+        const rset = new RecurrenceSet({
+          rrule: 'FREQ=WEEKLY;BYDAY=SA,SU;UNTIL=20240229',
+          dtstart: '20240203',
+          dtend: '20240203',
+        })
+
+        const recurrences = rset.getRecurrences()
+
+        expect(recurrences).toEqual([
+          {
+            start: '2024-02-03',
+            end: '2024-02-03',
+          },
+          {
+            start: '2024-02-04',
+            end: '2024-02-04',
+          },
+          {
+            start: '2024-02-10',
+            end: '2024-02-10',
+          },
+          {
+            start: '2024-02-11',
+            end: '2024-02-11',
+          },
+          {
+            start: '2024-02-17',
+            end: '2024-02-17',
+          },
+          {
+            start: '2024-02-18',
+            end: '2024-02-18',
+          },
+          {
+            start: '2024-02-24',
+            end: '2024-02-24',
+          },
+          {
+            start: '2024-02-25',
+            end: '2024-02-25',
+          },
+        ])
+      })
+      it('should return all mondays but one in May 2025', () => {
+        const exdate = ['20250507']
+        const rset = new RecurrenceSet({
+          rrule: 'FREQ=WEEKLY;BYDAY=MO;UNTIL=20250531',
+          dtstart: '20250501',
+          dtend: '20250501',
+          exdate,
+        })
+
+        const recurrences = rset.getRecurrences()
+
+        const expectedRecurrences = [
+          {
+            start: '2025-05-05',
+            end: '2025-05-05',
+          },
+          {
+            start: '2025-05-12',
+            end: '2025-05-12',
+          },
+          {
+            start: '2025-05-19',
+            end: '2025-05-19',
+          },
+          {
+            start: '2025-05-26',
+            end: '2025-05-26',
+          },
+        ]
+
+        expect(recurrences).toEqual(expectedRecurrences)
+        expect(recurrences).not.toEqual(
+          expect.arrayContaining([
+            {
+              start: '2025-05-07',
+              end: '2025-05-07',
+            },
+          ])
+        )
+        expect(recurrences.length).toBe(4)
+      })
     })
   })
 })

--- a/packages/recurrence/src/recurrence-set/__test__/get-monthly-rule.spec.ts
+++ b/packages/recurrence/src/recurrence-set/__test__/get-monthly-rule.spec.ts
@@ -62,4 +62,45 @@ describe('Getting monthly recurrences', () => {
       ])
     })
   })
+  it('should exclude datetimes specified in exdate', () => {
+    const exdate = ['20250601T103000', '20250701T103000', '20250801T103000']
+    const rset = new RecurrenceSet({
+      rrule: 'FREQ=MONTHLY;COUNT=5',
+      dtstart: '20250501T103000',
+      dtend: '20250501T113000',
+      exdate,
+    })
+
+    const recurrences = rset.getRecurrences()
+
+    const excludedFormattedDates = [
+      {
+        start: '2025-06-01 10:30',
+        end: '2025-06-01 11:30',
+      },
+      {
+        start: '2025-07-01 10:30',
+        end: '2025-07-01 11:30',
+      },
+      {
+        start: '2025-08-01 10:30',
+        end: '2025-08-01 11:30',
+      },
+    ]
+
+    expect(recurrences).toEqual([
+      {
+        start: '2025-05-01 10:30',
+        end: '2025-05-01 11:30',
+      },
+      {
+        start: '2025-09-01 10:30',
+        end: '2025-09-01 11:30',
+      },
+    ])
+    expect(recurrences).toHaveLength(2)
+    expect(recurrences).toEqual(
+      expect.not.arrayContaining(excludedFormattedDates)
+    )
+  })
 })

--- a/packages/recurrence/src/recurrence-set/__test__/get-weekly-recurrences.spec.ts
+++ b/packages/recurrence/src/recurrence-set/__test__/get-weekly-recurrences.spec.ts
@@ -100,5 +100,73 @@ describe('Getting weekly recurrences', () => {
         },
       ])
     })
+    it('should return 4 fridays in May, excluding 2025-05-30', () => {
+      const rset = new RecurrenceSet({
+        rrule: 'FREQ=WEEKLY;BYDAY=FR;UNTIL=20250531',
+        dtstart: '20250501',
+        dtend: '20250501',
+        exdate: ['20250530'],
+      })
+
+      const recurrences = rset.getRecurrences()
+
+      expect(recurrences).toEqual([
+        {
+          start: '2025-05-02',
+          end: '2025-05-02',
+        },
+        {
+          start: '2025-05-09',
+          end: '2025-05-09',
+        },
+        {
+          start: '2025-05-16',
+          end: '2025-05-16',
+        },
+        {
+          start: '2025-05-23',
+          end: '2025-05-23',
+        },
+      ])
+      expect(recurrences).not.toContainEqual({
+        start: '2025-05-30',
+        end: '2025-05-30',
+      })
+      expect(recurrences).toHaveLength(4)
+    })
+  })
+  describe('Using freq, byday and count', () => {
+    it('should return 3 Mondays in May 2025, excluding 2025-05-12', () => {
+      const rset = new RecurrenceSet({
+        rrule: 'FREQ=WEEKLY;BYDAY=MO;COUNT=4',
+        dtstart: '20250501T010000',
+        dtend: '20250501T020000',
+        exdate: ['20250512T010000'],
+      })
+
+      const recurrences = rset.getRecurrences()
+
+      const expectedRecurrences = [
+        {
+          start: '2025-05-05 01:00',
+          end: '2025-05-05 02:00',
+        },
+        {
+          start: '2025-05-19 01:00',
+          end: '2025-05-19 02:00',
+        },
+        {
+          start: '2025-05-26 01:00',
+          end: '2025-05-26 02:00',
+        },
+      ]
+
+      expect(recurrences).toEqual(expectedRecurrences)
+      expect(recurrences).not.toContainEqual({
+        start: '2025-05-12 01:00',
+        end: '2025-05-12 02:00',
+      })
+      expect(recurrences).toHaveLength(3)
+    })
   })
 })

--- a/packages/recurrence/src/recurrence-set/__test__/get-yearly-rule.spec.ts
+++ b/packages/recurrence/src/recurrence-set/__test__/get-yearly-rule.spec.ts
@@ -43,6 +43,48 @@ describe('Getting yearly recurrences', () => {
         },
       ])
     })
+    it('should generate yearly recurrences from 2025 excluding 2026', () => {
+      const rset = new RecurrenceSet({
+        rrule: 'FREQ=YEARLY;COUNT=6',
+        dtstart: '20250202',
+        dtend: '20250202',
+        exdate: ['20260202'],
+      })
+
+      const expectedRecurrences = [
+        {
+          start: '2025-02-02',
+          end: '2025-02-02',
+        },
+        {
+          start: '2027-02-02',
+          end: '2027-02-02',
+        },
+        {
+          start: '2028-02-02',
+          end: '2028-02-02',
+        },
+        {
+          start: '2029-02-02',
+          end: '2029-02-02',
+        },
+        {
+          start: '2030-02-02',
+          end: '2030-02-02',
+        },
+      ]
+
+      const excluded = {
+        start: '2026-02-02',
+        end: '2026-02-02',
+      }
+
+      const recurrences = rset.getRecurrences()
+
+      expect(recurrences).toEqual(expectedRecurrences)
+      expect(recurrences).toHaveLength(5)
+      expect(recurrences).not.toContainEqual(excluded)
+    })
   })
 
   describe('Using FREQ, UNTIL and INTERVAL', () => {
@@ -74,6 +116,34 @@ describe('Getting yearly recurrences', () => {
         },
       ]
       expect(recurrences).toEqual(expectedRecurrences)
+    })
+    it('should get every third year for 6 years, excluding 2028-05-02', () => {
+      const rset = new RecurrenceSet({
+        rrule: 'FREQ=YEARLY;UNTIL=20310502T150000;INTERVAL=3',
+        dtstart: '20250502T150000',
+        dtend: '20250502T150500',
+        exdate: ['20280502T150000'],
+      })
+
+      const recurrences = rset.getRecurrences()
+
+      const expectedRecurrences = [
+        {
+          start: '2025-05-02 15:00',
+          end: '2025-05-02 15:05',
+        },
+        {
+          start: '2031-05-02 15:00',
+          end: '2031-05-02 15:05',
+        },
+      ]
+
+      expect(recurrences).toEqual(expectedRecurrences)
+      expect(recurrences).toHaveLength(2)
+      expect(recurrences).not.toContainEqual({
+        start: '2028-05-02 15:00',
+        end: '2028-05-02 15:05',
+      })
     })
   })
 })

--- a/packages/recurrence/src/recurrence-set/__test__/parse-exdate-rule.spec.ts
+++ b/packages/recurrence/src/recurrence-set/__test__/parse-exdate-rule.spec.ts
@@ -1,0 +1,75 @@
+import {
+  describe,
+  it,
+  expect,
+} from '@schedule-x/shared/src/utils/stateless/testing/unit/unit-testing-library.impl'
+import { RecurrenceSet } from '../recurrence-set'
+
+describe('Parsing an Exdate string array into a map', () => {
+  describe('Using dates', () => {
+    it('should parse the dates from RFC5545 to SX format', () => {
+      const exdate = [
+        '20250501',
+        '20250507',
+        '20250515',
+        '20250521',
+        '20250530',
+        '20250531',
+      ]
+
+      const rset = new RecurrenceSet({
+        rrule: 'FREQ=WEEKLY;BYDAY=MO;UNTIL=20250509',
+        dtstart: '20250501',
+        dtend: '20240531',
+        exdate,
+      })
+
+      const mappedExdate = rset.getExdate()
+
+      expect(mappedExdate).toEqual(
+        new Map<string, boolean>([
+          ['2025-05-01', true],
+          ['2025-05-07', true],
+          ['2025-05-15', true],
+          ['2025-05-21', true],
+          ['2025-05-30', true],
+          ['2025-05-31', true],
+        ])
+      )
+      expect(mappedExdate?.size).toEqual(exdate.length)
+    })
+  })
+  describe('Using datetimes', () => {
+    it('should parse the datetimes from RFC5545 to SX format', () => {
+      const exdate = [
+        '20250501T010000',
+        '20250507T010000',
+        '20250515T010000',
+        '20250521T010000',
+        '20250530T010000',
+        '20250531T010000',
+      ]
+
+      const rset = new RecurrenceSet({
+        rrule: 'FREQ=WEEKLY;BYDAY=MO;UNTIL=20250509',
+        dtstart: '20250501T010000',
+        dtend: '20240531T020000',
+        exdate,
+      })
+
+      const mappedExdate = rset.getExdate()
+
+      expect(mappedExdate).toEqual(
+        new Map<string, boolean>([
+          ['2025-05-01 01:00', true],
+          ['2025-05-07 01:00', true],
+          ['2025-05-15 01:00', true],
+          ['2025-05-21 01:00', true],
+          ['2025-05-30 01:00', true],
+          ['2025-05-31 01:00', true],
+        ])
+      )
+      expect(mappedExdate?.size).toEqual(exdate.length)
+    })
+  })
+})

--- a/packages/recurrence/src/rrule/rrule.ts
+++ b/packages/recurrence/src/rrule/rrule.ts
@@ -18,11 +18,13 @@ export class RRule {
   constructor(
     options: RRuleOptionsExternal,
     private dtstart: string,
-    dtend?: string
+    dtend?: string,
+    exdate?: Map<string, boolean> | undefined
   ) {
     this.options = {
       ...options,
       interval: options.interval ?? 1,
+      exdate,
     }
 
     const actualDTEND = dtend || dtstart /* RFC5545: #1 */

--- a/packages/recurrence/src/rrule/types/rrule-options.ts
+++ b/packages/recurrence/src/rrule/types/rrule-options.ts
@@ -9,6 +9,7 @@ export interface RRuleOptions {
   count?: number
   byday?: string[]
   bymonthday?: number
+  exdate?: Map<string, boolean> | undefined
   wkst?: RFC5455Weekday
 }
 

--- a/packages/recurrence/src/rrule/utils/stateless/daily-iterator.ts
+++ b/packages/recurrence/src/rrule/utils/stateless/daily-iterator.ts
@@ -6,29 +6,35 @@ import { addDays } from '@schedule-x/shared/src'
 
 const dailyIterator = (dtstart: string, rruleOptions: RRuleOptions) => {
   let currentDate = dtstart
+  let currentCount: number = 0
   const allDateTimes: string[] = []
   const bydayNumbers: number[] | undefined =
     rruleOptions.byday?.map(getJSDayFromByday) || undefined
+  const mappedExdate = rruleOptions.exdate
 
   return {
     next() {
       if (
-        !isCountReached(allDateTimes.length, rruleOptions.count) &&
+        !isCountReached(currentCount, rruleOptions.count) &&
         !isDatePastUntil(currentDate, rruleOptions.until)
       ) {
-        if (bydayNumbers) {
-          const dayOfWeek = toJSDate(currentDate).getDay()
-          if (bydayNumbers.includes(dayOfWeek)) {
+        if (!mappedExdate?.has(currentDate)) {
+          if (bydayNumbers) {
+            const dayOfWeek = toJSDate(currentDate).getDay()
+            if (bydayNumbers.includes(dayOfWeek)) {
+              allDateTimes.push(currentDate)
+            }
+          } else {
             allDateTimes.push(currentDate)
           }
-        } else {
-          allDateTimes.push(currentDate)
         }
+
+        currentCount++
       }
 
       if (
         isDatePastUntil(currentDate, rruleOptions.until) ||
-        isCountReached(allDateTimes.length, rruleOptions.count)
+        isCountReached(currentCount, rruleOptions.count)
       ) {
         return { done: true, value: allDateTimes }
       }

--- a/packages/recurrence/src/rrule/utils/stateless/monthly-iterators.ts
+++ b/packages/recurrence/src/rrule/utils/stateless/monthly-iterators.ts
@@ -5,20 +5,25 @@ import { toIntegers } from '@schedule-x/shared/src/utils/stateless/time/format-c
 
 const monthlyIteratorBymonthday = (dtstart: string, options: RRuleOptions) => {
   let currentDate = dtstart
+  let currentCount: number = 0
   const allDateTimes: string[] = []
+  const mappedExdate = options.exdate
 
   return {
     next() {
       if (
-        !isCountReached(allDateTimes.length, options.count) &&
+        !isCountReached(currentCount, options.count) &&
         !isDatePastUntil(currentDate, options.until)
       ) {
-        allDateTimes.push(currentDate)
+        if (!mappedExdate?.has(currentDate)) {
+          allDateTimes.push(currentDate)
+        }
+        currentCount++
       }
 
       if (
         isDatePastUntil(currentDate, options.until) ||
-        isCountReached(allDateTimes.length, options.count)
+        isCountReached(currentCount, options.count)
       ) {
         return { done: true, value: allDateTimes }
       }

--- a/packages/recurrence/src/rrule/utils/stateless/weekly-iterator.ts
+++ b/packages/recurrence/src/rrule/utils/stateless/weekly-iterator.ts
@@ -12,12 +12,14 @@ const weeklyIterator = (dtstart: string, rruleOptions: RRuleOptions) => {
     toJSDate(dtstart).getDay(),
   ]
   let currentDate = dtstart
+  let currentCount: number = 0
   const allDateTimes: string[] = []
   const firstDayOfWeek = (
     rruleOptions.wkst
       ? ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'].indexOf(rruleOptions.wkst)
       : 0
   ) as 0 | 1 | 2 | 3 | 4 | 5 | 6
+  const mappedExdate = rruleOptions.exdate
 
   return {
     next() {
@@ -37,13 +39,16 @@ const weeklyIterator = (dtstart: string, rruleOptions: RRuleOptions) => {
           !isCountReached(allDateTimes.length, rruleOptions.count) &&
           !isDatePastUntil(candidate, rruleOptions.until)
         ) {
-          allDateTimes.push(candidate)
+          if (!mappedExdate?.has(candidate)) {
+            allDateTimes.push(candidate)
+          }
+          currentCount++
         }
       })
 
       if (
         isDatePastUntil(currentDate, rruleOptions.until) ||
-        isCountReached(allDateTimes.length, rruleOptions.count)
+        isCountReached(currentCount, rruleOptions.count)
       ) {
         return { done: true, value: allDateTimes }
       }

--- a/packages/recurrence/src/rrule/utils/stateless/yearly-iterator.ts
+++ b/packages/recurrence/src/rrule/utils/stateless/yearly-iterator.ts
@@ -5,19 +5,24 @@ import { addYears } from '@schedule-x/shared/src/utils/stateless/time/date-time-
 const yearlyIterator = (dtstart: string, rruleOptions: RRuleOptions) => {
   const allDateTimes: string[] = []
   let currentDate = dtstart
+  let currentCount: number = 0
+  const mappedExdate = rruleOptions.exdate
 
   return {
     next() {
       if (
-        !isCountReached(allDateTimes.length, rruleOptions.count) &&
+        !isCountReached(currentCount, rruleOptions.count) &&
         !isDatePastUntil(currentDate, rruleOptions.until)
       ) {
-        allDateTimes.push(currentDate)
+        if (!mappedExdate?.has(currentDate)) {
+          allDateTimes.push(currentDate)
+        }
+        currentCount++
       }
 
       if (
         isDatePastUntil(currentDate, rruleOptions.until) ||
-        isCountReached(allDateTimes.length, rruleOptions.count)
+        isCountReached(currentCount, rruleOptions.count)
       ) {
         return { done: true, value: allDateTimes }
       }


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [X] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [X] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR).  (#732)
- [X] If committing a new feature, I have also written the appropriate tests for it. 
- [X] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem. 

This PR adds support for excluding specific dates from a recurrence rule using the exdate property.

It follows the [RFC 5545 specification](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.5.1) for date and datetime formats.

## How to test this PR. 

Provide RFC5545-compliant date strings to the `exdate` property (as an array of strings) inside the event object
```
{
      title: 'Date event',
      id: 1,
      start: '2025-05-02',
      end: '2025-05-02',
      rrule: 'FREQ=DAILY;INTERVAL=1;UNTIL=20250531',
      exdate: ['20250507', '20250508', '20250509', '20250510', '20250529'],
}
```
or RFC5545-compliant datetime strings:
```
{
      title: 'Datetime event',
      id: 2,
      start: '2025-05-02 10:30',
      end: '2025-05-02 11:00',
      rrule: 'FREQ=DAILY;INTERVAL=1;UNTIL=20250531',
      exdate: ['20250507T103000', '20250508T103000', '20250509T103000', '20250510T103000', '20250529T103000'],
}
```