### PR TITLE
fix(event-recurrence): skipping first not aligned date when BYDAY is set

### DIFF
--- a/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
+++ b/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
@@ -58,17 +58,17 @@ export const createRecurrencesForBackgroundEvent = (
     dtstart: parseSXToRFC5545(backgroundEvent.start),
     dtend: parseSXToRFC5545(backgroundEvent.end),
     rrule,
-  })
+  }).getRecurrences()
 
-  return recurrenceSet
-    .getRecurrences()
-    .slice(1) // skip the first occurrence because this is the original event
-    .map((recurrence) => {
-      const eventCopy: AugmentedBackgroundEvent =
-        structuredClone(backgroundEvent)
-      eventCopy.start = recurrence.start
-      eventCopy.end = recurrence.end
-      eventCopy.isCopy = true
-      return eventCopy
-    })
+  if (recurrenceSet[0].start === backgroundEvent.start) {
+    recurrenceSet.splice(0, 1) // skip the first occurrence because this is the original event
+  }
+
+  return recurrenceSet.map((recurrence) => {
+    const eventCopy: AugmentedBackgroundEvent = structuredClone(backgroundEvent)
+    eventCopy.start = recurrence.start
+    eventCopy.end = recurrence.end
+    eventCopy.isCopy = true
+    return eventCopy
+  })
 }

--- a/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
+++ b/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
@@ -30,7 +30,7 @@ export const createRecurrencesForEvent = (
     exdate,
   }).getRecurrences()
 
-  if (recurrenceSet[0].start == calendarEvent.start) {
+  if (recurrenceSet[0].start === calendarEvent.start) {
     recurrenceSet.splice(0, 1) // skip the first occurrence because this is the original event
   }
 

--- a/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
+++ b/packages/event-recurrence/src/util/stateless/create-recurrences-for-event.ts
@@ -28,18 +28,19 @@ export const createRecurrencesForEvent = (
     dtend: parseSXToRFC5545(calendarEvent.end),
     rrule,
     exdate,
-  })
+  }).getRecurrences()
 
-  return recurrenceSet
-    .getRecurrences()
-    .slice(1) // skip the first occurrence because this is the original event
-    .map((recurrence) => {
-      const eventCopy: AugmentedEvent = deepCloneEvent(calendarEvent, $app)
-      eventCopy.start = recurrence.start
-      eventCopy.end = recurrence.end
-      eventCopy.isCopy = true
-      return eventCopy
-    })
+  if (recurrenceSet[0].start == calendarEvent.start) {
+    recurrenceSet.splice(0, 1) // skip the first occurrence because this is the original event
+  }
+
+  return recurrenceSet.map((recurrence) => {
+    const eventCopy: AugmentedEvent = deepCloneEvent(calendarEvent, $app)
+    eventCopy.start = recurrence.start
+    eventCopy.end = recurrence.end
+    eventCopy.isCopy = true
+    return eventCopy
+  })
 }
 
 export const createRecurrencesForBackgroundEvent = (


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [X] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [X] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [X] If committing a new feature, I have also written the appropriate tests for it. 
- [X] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem. 

This PR should fix #1062.

## How to test this PR. 
The event
```
{
      id: 123,
      title: 'Weekly event',
      start: '2025-05-17 14:00',
      end: '2025-05-17 15:00',
      rrule: 'RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20251231T235959;BYDAY=FR',
}
```
will now be displayed correctly
![image](https://github.com/user-attachments/assets/4d0a81be-3f9f-450c-bbb7-3f9e6a508860)


