### PR TITLE
feat(translations): add Persian (fa-IR) locale support

### DIFF
--- a/packages/translations/src/index.ts
+++ b/packages/translations/src/index.ts
@@ -64,6 +64,8 @@ import { fiFI } from './locales/fi-FI'
 import { datePickerFiFI } from './locales/fi-FI/date-picker'
 import { roRO } from './locales/ro-RO'
 import { datePickerRoRO } from './locales/ro-RO/date-picker'
+import { faIR } from './locales/fa-IR'
+import { datePickerFaIR } from './locales/fa-IR/date-picker'
 
 import { translate } from './translator/translate'
 import { mergeLocales } from './utils/merge-locales'
@@ -104,6 +106,7 @@ const translations = {
   slSI,
   fiFI,
   roRO,
+  faIR,
 }
 
 const datePickerTranslations = {
@@ -141,6 +144,7 @@ const datePickerTranslations = {
   fiFI: datePickerFiFI,
   roRO: datePickerRoRO,
   heIL: datePickerHeIL,
+  faIR: datePickerFaIR,
 }
 
 export {
@@ -181,4 +185,5 @@ export {
   fiFI,
   roRO,
   heIL,
+  faIR,
 }

--- a/packages/translations/src/locales/fa-IR/calendar.ts
+++ b/packages/translations/src/locales/fa-IR/calendar.ts
@@ -1,0 +1,21 @@
+import { CalendarTranslations } from '@schedule-x/shared/src/types/translations/calendar.translations'
+
+export const calendarFaIR: CalendarTranslations = {
+  today: 'امروز',
+  Month: 'ماه',
+  Week: 'هفته',
+  Day: 'روز',
+  'Select View': 'انتخاب نما',
+  events: 'رویدادها',
+  event: 'رویداد',
+  'No events': 'رویدادی وجود ندارد',
+  'Next period': 'دوره بعدی',
+  'Previous period': 'دوره قبلی',
+  to: 'تا',
+  'Full day- and multiple day events': 'رویدادهای تمام روز و چند روزه',
+  'Link to {{n}} more events on {{date}}':
+    'لینک به {{n}} رویداد بیشتر در تاریخ {{date}}',
+  'Link to 1 more event on {{date}}':
+    'لینک به 1 رویداد بیشتر در تاریخ {{date}}',
+  CW: 'هفته {{week}}',
+}

--- a/packages/translations/src/locales/fa-IR/calendar.ts
+++ b/packages/translations/src/locales/fa-IR/calendar.ts
@@ -1,7 +1,7 @@
 import { CalendarTranslations } from '@schedule-x/shared/src/types/translations/calendar.translations'
 
 export const calendarFaIR: CalendarTranslations = {
-  today: 'امروز',
+  Today: 'امروز',
   Month: 'ماه',
   Week: 'هفته',
   Day: 'روز',

--- a/packages/translations/src/locales/fa-IR/date-picker.ts
+++ b/packages/translations/src/locales/fa-IR/date-picker.ts
@@ -1,0 +1,9 @@
+import { DatePickerTranslations } from '@schedule-x/shared/src/types/translations/date-picker.translations'
+
+export const datePickerFaIR: DatePickerTranslations = {
+  Date: 'تاریخ',
+  'MM/DD/YYYY': 'MM/DD/YYYY',
+  'Next month': 'ماه بعد',
+  'Previous month': 'ماه قبل',
+  'Choose Date': 'انتخاب تاریخ',
+}

--- a/packages/translations/src/locales/fa-IR/index.ts
+++ b/packages/translations/src/locales/fa-IR/index.ts
@@ -1,0 +1,10 @@
+import { datePickerFaIR } from './date-picker'
+import { Language } from '@schedule-x/shared/src/types/translations/language.translations'
+import { calendarFaIR } from './calendar'
+import { timePickerFaIR } from './time-picker'
+
+export const enUS: Language = {
+  ...datePickerFaIR,
+  ...calendarFaIR,
+  ...timePickerFaIR,
+}

--- a/packages/translations/src/locales/fa-IR/index.ts
+++ b/packages/translations/src/locales/fa-IR/index.ts
@@ -3,7 +3,7 @@ import { Language } from '@schedule-x/shared/src/types/translations/language.tra
 import { calendarFaIR } from './calendar'
 import { timePickerFaIR } from './time-picker'
 
-export const enUS: Language = {
+export const faIR: Language = {
   ...datePickerFaIR,
   ...calendarFaIR,
   ...timePickerFaIR,

--- a/packages/translations/src/locales/fa-IR/time-picker.ts
+++ b/packages/translations/src/locales/fa-IR/time-picker.ts
@@ -1,0 +1,10 @@
+import { TimePickerTranslations } from '@schedule-x/shared/src/types/translations/time-picker.translations'
+
+export const timePickerFaIR: TimePickerTranslations = {
+  Time: 'زمان',
+  AM: 'ق.ظ',
+  PM: 'ب.ظ',
+  Cancel: 'لغو',
+  OK: 'تایید',
+  'Select time': 'انتخاب زمان',
+}

--- a/website/pages/docs/calendar/language.mdx
+++ b/website/pages/docs/calendar/language.mdx
@@ -46,6 +46,7 @@ your translations under the folder: `packages/translations/src/locales/xx-XX`
 | Swedish                  | sv-SE      |
 | Turkish                  | tr-TR      |
 | Ukrainian                | uk-UA      |
+| Persian                  | fa-IR      |
 
 ## Customizing the translations
 

--- a/website/pages/docs/calendar/language.mdx
+++ b/website/pages/docs/calendar/language.mdx
@@ -34,6 +34,7 @@ your translations under the folder: `packages/translations/src/locales/xx-XX`
 | Kyrgyz                   | ky-KG      |
 | Lithuanian               | lt-LT      |
 | Macedonian               | mk-MK      |
+| Persian                  | fa-IR      |
 | Polish                   | pl-PL      |
 | Portuguese (BR)          | pt-BR      |
 | Romanian                 | ro-RO      |
@@ -46,7 +47,6 @@ your translations under the folder: `packages/translations/src/locales/xx-XX`
 | Swedish                  | sv-SE      |
 | Turkish                  | tr-TR      |
 | Ukrainian                | uk-UA      |
-| Persian                  | fa-IR      |
 
 ## Customizing the translations
 


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [X] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

Adds the support for Persian (fa-IR) language
## How to test this PR**. 
Just add 'fa-IR' to locale
For example:  
1. Feed X and Y in the events-Prop. 
2. Click Z or A. 
3. Confirm that B is displayed. 
