### PR TITLE
fix: reset monthly events pointer-events on mouseup

### DIFF
--- a/packages/drag-and-drop/src/__test__/month-grid-drag-handler/month-grid-drag-handler.spec.ts
+++ b/packages/drag-and-drop/src/__test__/month-grid-drag-handler/month-grid-drag-handler.spec.ts
@@ -71,6 +71,22 @@ describe('MonthGridDragHandler', () => {
       expect(otherEvent.style.pointerEvents).toBe('auto')
     })
 
+    it('should set pointer events to none for other events, and then back to auto on mouse up', () => {
+      const fourthOfJanuaryElement = document.createElement('div')
+      fourthOfJanuaryElement.classList.add('sx__month-grid-day')
+      fourthOfJanuaryElement.dataset.date = '2021-01-04'
+      const otherEvent = document.createElement('div')
+      otherEvent.classList.add('sx__event')
+      $app.elements.calendarWrapper!.appendChild(fourthOfJanuaryElement)
+      $app.elements.calendarWrapper!.appendChild(otherEvent)
+      new MonthGridDragHandlerImpl(calendarEvent, $app)
+
+      expect(otherEvent.style.pointerEvents).toBe('none')
+
+      document.dispatchEvent(new MouseEvent('mouseup'))
+      expect(otherEvent.style.pointerEvents).toBe('auto')
+    })
+
     it('should add a class for the dragover day to signal it is active', () => {
       const fourthOfJanuaryElement = document.createElement('div')
       fourthOfJanuaryElement.classList.add('sx__month-grid-day')

--- a/packages/drag-and-drop/src/month-grid-drag-handler.impl.ts
+++ b/packages/drag-and-drop/src/month-grid-drag-handler.impl.ts
@@ -38,6 +38,7 @@ export default class MonthGridDragHandlerImpl implements MonthGridDragHandler {
 
   private init() {
     document.addEventListener('dragend', this.handleDragEnd, { once: true })
+    document.addEventListener('mouseup', this.handleMouseUp, { once: true })
     this.allDayElements.forEach((el) => {
       el.addEventListener('dragover', this.handleDragOver)
     })
@@ -74,6 +75,7 @@ export default class MonthGridDragHandlerImpl implements MonthGridDragHandler {
   }
 
   private handleDragEnd = async () => {
+    document.removeEventListener('mouseup', this.handleMouseUp)
     this.allDayElements.forEach((el) => {
       el.removeEventListener('dragover', this.handleDragOver)
       el.classList.remove(this.DAY_DRAGOVER_CLASS_NAME)
@@ -92,6 +94,11 @@ export default class MonthGridDragHandlerImpl implements MonthGridDragHandler {
     if (shouldAbort) return
 
     this.updateCalendarEvent(updatedEvent)
+  }
+
+  private handleMouseUp = async () => {
+    document.removeEventListener('dragend', this.handleDragEnd)
+    this.setCalendarEventPointerEventsTo('auto')
   }
 
   private setCalendarEventPointerEventsTo = (


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [x] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [x] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [x] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

This aims at solving this bug: https://github.com/schedule-x/schedule-x/issues/1125

## How to test this PR**. 

For example:  
1. Press down mouse button on a monthly event without dragging 
2. Release mouse button
3. Move another event. It should work as expected.
