### PR TITLE
fix(deps): relax temporal-polyfill peer dependency from exact version to semver range

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@preact/signals": "^2.0.2",
     "preact": "^10.19.2",
-    "temporal-polyfill": "0.3.0"
+    "temporal-polyfill": "^0.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## This PR solves the following problem: 

The current version of temporal-polyfill is 0.3.2, which exposes an issue where @schedule-x/calendar declares an exact peer dependency on "0.3.0". Under npm 7+ strict peer resolution, this causes installation failures whenever a different patch version (such as 0.3.2) is used, effectively blocking consumers from using compatible patch releases.

## Fix:

Relax the peer dependency to allow compatible patch versions.