### PR TITLE
feat (calendar): added spacing around events and date-grid-day

### DIFF
--- a/packages/calendar/src/components/week-grid/time-grid-event.tsx
+++ b/packages/calendar/src/components/week-grid/time-grid-event.tsx
@@ -261,23 +261,27 @@ export default function TimeGridEvent({
             calendarEvent._maxConcurrentEvents,
             $app.config.weekOptions.value.eventOverlap
           )}%`,
-          backgroundColor: customComponent
-            ? undefined
-            : eventCSSVariables.backgroundColor,
-          color: customComponent ? undefined : eventCSSVariables.textColor,
-          borderTop: borderRule,
-          borderInlineEnd: borderRule,
-          borderBottom: borderRule,
-          borderInlineStart: customComponent
-            ? undefined
-            : eventCSSVariables.borderInlineStart,
-          padding: customComponent ? '0' : undefined,
         }}
       >
         <div
-          data-ccid={customComponentId.current}
-          className="sx__time-grid-event-inner"
+          className="sx__time-grid-event-content"
+          style={{
+            backgroundColor: customComponent
+              ? undefined
+              : eventCSSVariables.backgroundColor,
+            color: customComponent ? undefined : eventCSSVariables.textColor,
+            borderTop: borderRule,
+            borderInlineEnd: borderRule,
+            borderBottom: borderRule,
+            borderInlineStart: customComponent
+              ? undefined
+              : eventCSSVariables.borderInlineStart,
+          }}
         >
+          <div
+            data-ccid={customComponentId.current}
+            className="sx__time-grid-event-inner"
+          >
           {!customComponent && !hasCustomContent && (
             <Fragment>
               {/* Compact layout - title and time inline */}
@@ -345,6 +349,7 @@ export default function TimeGridEvent({
                 onTouchStart={startResize}
               />
             )}
+        </div>
         </div>
       </div>
 

--- a/packages/theme-default/src/components/calendar/week-grid/date-grid.scss
+++ b/packages/theme-default/src/components/calendar/week-grid/date-grid.scss
@@ -14,6 +14,7 @@ $event-overflow-margin: 10px; // CORRELATION ID: 1
   width: 100%;
   display: grid;
   grid-gap: 2px;
+  padding: 2px 0px 2px 0px;
 
   /* needed for the draw plugin */
   .sx__spacer {

--- a/packages/theme-default/src/components/calendar/week-grid/time-grid-event.scss
+++ b/packages/theme-default/src/components/calendar/week-grid/time-grid-event.scss
@@ -2,11 +2,9 @@
 
 .sx__time-grid-event {
   width: calc(100% - 10px);
-  padding: var(--sx-spacing-padding1);
   position: absolute;
-  border-radius: var(--sx-rounding-extra-small);
-  font-size: var(--sx-font-extra-small);
-  overflow: hidden;
+  padding: 1px;
+  box-sizing: border-box;
   -webkit-user-select: none;
   user-select: none;
 
@@ -18,6 +16,15 @@
   }
 
   @include events.is-event-new;
+}
+
+.sx__time-grid-event-content {
+  height: 100%;
+  border-radius: var(--sx-rounding-extra-small);
+  font-size: var(--sx-font-extra-small);
+  overflow: hidden;
+  box-sizing: border-box;
+  padding: var(--sx-spacing-padding1);
 }
 
 [data-has-dnd='true'] {

--- a/packages/theme-shadcn/src/index.scss
+++ b/packages/theme-shadcn/src/index.scss
@@ -26,7 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   }
 
   .sx__month-grid-event,
-  .sx__time-grid-event,
+  .sx__time-grid-event-content,
   .sx__date-grid-event,
   .sx__month-agenda-event {
     border-radius: var(--sx-event-border-radius);


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [ ] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [X] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). :warning: Probably! Untested!

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

#1307

Spacing around events:

<img width="329" height="333" alt="a" src="https://github.com/user-attachments/assets/13962fcf-c1a2-4ab2-a77f-0aa76f61ae02" />

Spacing above and below date-grid-day:

<img width="388" height="174" alt="b" src="https://github.com/user-attachments/assets/40f23579-5428-431b-b3a7-93d83e946d5a" />