### PR TITLE
fix: `onClickPlusEvents` override behavior

### DIFF
--- a/packages/calendar/src/views/month-grid/components/__test__/month-day.spec.tsx
+++ b/packages/calendar/src/views/month-grid/components/__test__/month-day.spec.tsx
@@ -148,6 +148,50 @@ describe('MonthDay component', () => {
       )
     })
 
+    it('should not navigate to day view when clicking on the more events button if callback exists', async () => {
+      renderComponent($app, dayWithEventLimitPlus2)
+      expect($app.calendarState.view.value).toBe(InternalViewName.Week)
+
+      const moreEventsButton = document.querySelector(
+        '.sx__month-grid-day__events-more'
+      )
+      moreEventsButton?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+
+      await waitFor(() => {
+        expect($app.calendarState.view.value).toBe(InternalViewName.Week)
+      })
+    })
+
+    it('should not propagate click to the day, when clicking on the more events button', () => {
+      renderComponent($app, dayWithEventLimitPlus2)
+      const moreEventsButton = document.querySelector(
+        '.sx__month-grid-day__events-more'
+      )
+      moreEventsButton?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+
+      expect(onClickDate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clicking "+ N events" without callback', () => {
+    const $app = __createAppWithViews__()
+    const dayWithEventLimitPlus2: MonthDayType = {
+      date: Temporal.PlainDate.from('2020-01-01'),
+      events: {
+        '0': getTestEvent($app),
+        '1': getTestEvent($app),
+        '2': getTestEvent($app),
+        '3': getTestEvent($app),
+        '4': getTestEvent($app),
+        '5': getTestEvent($app),
+      },
+      backgroundEvents: [],
+    }
+
     it('should navigate to day view when clicking on the more events button', async () => {
       renderComponent($app, dayWithEventLimitPlus2)
       expect($app.calendarState.view.value).toBe(InternalViewName.Week)
@@ -162,18 +206,6 @@ describe('MonthDay component', () => {
       await waitFor(() => {
         expect($app.calendarState.view.value).toBe(InternalViewName.Day)
       })
-    })
-
-    it('should not propagate click to the day, when clicking on the more events button', () => {
-      renderComponent($app, dayWithEventLimitPlus2)
-      const moreEventsButton = document.querySelector(
-        '.sx__month-grid-day__events-more'
-      )
-      moreEventsButton?.dispatchEvent(
-        new MouseEvent('click', { bubbles: true })
-      )
-
-      expect(onClickDate).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/calendar/src/views/month-grid/components/month-grid-day.tsx
+++ b/packages/calendar/src/views/month-grid/components/month-grid-day.tsx
@@ -48,8 +48,10 @@ export default function MonthGridDay({ day, isFirstWeek, isLastWeek }: props) {
   const handleClickAdditionalEvents = (e: MouseEvent | TouchEvent) => {
     e.stopPropagation()
 
-    if ($app.config.callbacks.onClickPlusEvents)
+    if ($app.config.callbacks.onClickPlusEvents) {
       $app.config.callbacks.onClickPlusEvents(day.date, e)
+      return
+    }
     if (
       !$app.config.views.value.find(
         (view) => view.name === InternalViewName.Day


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply:

- [x] If committing a change of production code, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written the appropriate tests for it. 
- [x] I have tried to build the feature in a way, that it does not cause any breaking changes for others (unless 
  agreed upon in an issue). 

**Premium**
- [ ] I'm a Schedule-X premium user

## This PR solves the following problem**. 

https://github.com/schedule-x/schedule-x/issues/1322

## How to test this PR**. 

For example:  
1. Open calendar in month view
2. Find day with "+ N events"
3. Click on it
4. Confirm it only console logs, it does not open day view
