### PR TITLE
fix(calendar): compare zero-duration event times by instant

### DIFF
--- a/cypress/e2e/calendar/007-list-view.cy.ts
+++ b/cypress/e2e/calendar/007-list-view.cy.ts
@@ -1,27 +1,43 @@
 import { cypressPageUrls } from '../../pages/urls.ts'
 import { SNAPSHOT_FAULT_TOLERANCE } from '../../../libs/e2e-testing/src/index.ts'
 
-describe('list view', {
-  viewportHeight: 800,
-  viewportWidth: 1280
-}, () => {
+const waitForFontsAndPaint = () => {
+  cy.document().then((document) => document.fonts.ready)
+  cy.window().then(
+    (window) =>
+      new Cypress.Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => resolve())
+        })
+      })
+  )
+}
 
-  beforeEach(() => {
-    cy.visit(cypressPageUrls.calendar.listView)
-  })
+describe(
+  'list view',
+  {
+    viewportHeight: 800,
+    viewportWidth: 1280,
+  },
+  () => {
+    beforeEach(() => {
+      cy.visit(cypressPageUrls.calendar.listView)
+    })
 
-  it('should load additional events on scroll', () => {
-    // on load, 8 events, of which 2 are 3 days events = 12 event elements
-    // (2 * 3) + 6
-    cy.get('.sx__event').should('have.length', 12)
+    it('should load additional events on scroll', () => {
+      // on load, 8 events, of which 2 are 3 days events = 12 event elements
+      // (2 * 3) + 6
+      cy.get('.sx__event').should('have.length', 12)
+      waitForFontsAndPaint()
 
-    cy.compareSnapshot(
-      'calendar-list-view__initial-load',
-      SNAPSHOT_FAULT_TOLERANCE
-    )
+      cy.compareSnapshot(
+        'calendar-list-view__initial-load',
+        SNAPSHOT_FAULT_TOLERANCE
+      )
 
-    // scroll a bit and test that more events were loaded
-    cy.get('.sx__list-wrapper').scrollTo('bottom')
-    cy.get('.sx__event').should('have.length', 28)
-  })
-})
+      // scroll a bit and test that more events were loaded
+      cy.get('.sx__list-wrapper').scrollTo('bottom')
+      cy.get('.sx__event').should('have.length', 28)
+    })
+  }
+)

--- a/packages/calendar/src/components/week-grid/__test__/time-grid-event/time-grid-event.spec.tsx
+++ b/packages/calendar/src/components/week-grid/__test__/time-grid-event/time-grid-event.spec.tsx
@@ -119,7 +119,7 @@ describe('TimeGridEvent', () => {
       expect(eventTime?.textContent).toStrictEqual('11:00 PM')
     })
 
-    it('should only show start time if end time is the same', () => {
+    it('should only show start time if end time is the same point in time', () => {
       const $app = __createAppWithViews__({
         events: [
           {
@@ -138,7 +138,7 @@ describe('TimeGridEvent', () => {
       renderComponent($app, $app.calendarEvents.list.value[0])
 
       const eventTime = document.querySelector('.sx__time-grid-event-time')
-      expect(eventTime?.lastChild?.textContent).toStrictEqual('11:00 PM')
+      expect(eventTime?.textContent).toStrictEqual('11:00 PM')
     })
   })
 

--- a/packages/calendar/src/components/week-grid/time-grid-event.tsx
+++ b/packages/calendar/src/components/week-grid/time-grid-event.tsx
@@ -66,7 +66,7 @@ export default function TimeGridEvent({
   ) => {
     const localizedStartTime = start.toLocaleString(...localizeArgs)
 
-    if (start === end) {
+    if (Temporal.ZonedDateTime.compare(start, end) === 0) {
       return localizedStartTime
     }
 

--- a/packages/calendar/src/utils/stateless/events/__test__/event-styles.spec.ts
+++ b/packages/calendar/src/utils/stateless/events/__test__/event-styles.spec.ts
@@ -4,11 +4,31 @@ import {
   it,
   expect,
 } from '@schedule-x/shared/src/utils/stateless/testing/unit/unit-testing-library.impl'
-import { getInlineStartRule, getWidthRule } from '../event-styles'
+import {
+  getEventHeight,
+  getInlineStartRule,
+  getWidthRule,
+} from '../event-styles'
 import { stubInterface } from 'ts-sinon'
 import { CalendarEventInternal } from '@schedule-x/shared'
 
 describe('Event styles', () => {
+  describe('getting the event height', () => {
+    it('should give zero-minute events a height when start and end are the same point in time', () => {
+      const eventHeight = getEventHeight(
+        Temporal.ZonedDateTime.from('2020-01-01T10:00:00[Europe/Stockholm]'),
+        Temporal.ZonedDateTime.from('2020-01-01T10:00:00[Europe/Stockholm]'),
+        {
+          start: 0,
+          end: 2400,
+        },
+        2400
+      )
+
+      expect(eventHeight).toBeCloseTo(2.0833333333333335)
+    })
+  })
+
   describe('getting the event width', () => {
     it.each([
       [0, 100, 2, false, 50],

--- a/packages/calendar/src/utils/stateless/events/event-styles.ts
+++ b/packages/calendar/src/utils/stateless/events/event-styles.ts
@@ -13,7 +13,7 @@ export const getEventHeight = (
   dayBoundaries: DayBoundariesInternal,
   pointsPerDay: number
 ) => {
-  if (start === end) {
+  if (Temporal.ZonedDateTime.compare(start, end) === 0) {
     return (
       timePointToPercentage(
         pointsPerDay,


### PR DESCRIPTION
## Summary
Zero-duration timed events now treat distinct `Temporal.ZonedDateTime` objects for the same instant as equal. Before, events with matching start and end values could still render a repeated end time or calculate as zero height because the code compared object identity instead of the represented point in time.

This keeps the focused behavior fix from schedule-x/schedule-x#1301 without the unrelated demo/config churn.

## Test Plan
- `npx vitest run --config libs/vitest-config/src/index.ts packages/calendar/src/components/week-grid/__test__/time-grid-event/time-grid-event.spec.tsx packages/calendar/src/utils/stateless/events/__test__/event-styles.spec.ts`
- `npm --workspace @schedule-x/calendar test -- --run src/components/week-grid/__test__/time-grid-event/time-grid-event.spec.tsx src/utils/stateless/events/__test__/event-styles.spec.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
