### PR TITLE
docs: sync premium changelog

### DIFF
--- a/website/app/premium-changelog/page.mdx
+++ b/website/app/premium-changelog/page.mdx
@@ -1,5 +1,22 @@
 # Change Log
 
+## 15.4.0 (2026-07-15)
+
+### Bug Fixes
+
+* **modal:** fix release build type errors
+* **resource-scheduler:** drag-to-new-resource when pointer is over another event
+
+### Features
+
+* **sidebar:** add defaultCalendarId option to createSidebarPlugin
+
+## 15.3.2 (2026-03-09)
+
+### Bug Fixes
+
+* **modal:** z-index
+
 ## 15.3.1 (2026-03-02)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary
- mirror premium changelog entries for 15.4.0 and 15.3.2
- convert generated private changelog links into the public website changelog format

## Verification
- ran sync-premium-changelog helper script
- ran git diff --check