### PR TITLE
feat(calendar): configurable event sorting for month views

### DIFF
--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -35,6 +35,10 @@ import TimeAxis from './components/week-grid/time-axis'
 import DateGridDay from './components/week-grid/date-grid-day'
 import { Week } from './types/week'
 import { sortEventsForWeekView } from './utils/stateless/events/sort-events-for-week'
+import {
+  sortEventsForMonthGrid,
+  sortEventsByStartAndEnd,
+} from './utils/stateless/events/sort-by-start-date'
 import { AppContext } from './utils/stateful/app-context'
 
 export type {
@@ -79,5 +83,7 @@ export {
   TimeAxis,
   DateGridDay,
   sortEventsForWeekView,
+  sortEventsForMonthGrid,
+  sortEventsByStartAndEnd,
   AppContext,
 }

--- a/packages/calendar/src/views/month-agenda/components/__test__/month-agenda-wrapper.spec.tsx
+++ b/packages/calendar/src/views/month-agenda/components/__test__/month-agenda-wrapper.spec.tsx
@@ -412,4 +412,68 @@ describe('MonthAgendaWrapper', () => {
       ).toHaveLength(4)
     })
   })
+
+  describe('custom event sorting', () => {
+    const getAgendaTitles = () =>
+      Array.from(
+        document.querySelectorAll('.sx__month-agenda-event__title')
+      ).map((el) => el.textContent)
+
+    const sameDayEvents = [
+      {
+        id: 1,
+        title: 'A',
+        start: Temporal.ZonedDateTime.from(
+          '2027-01-27T09:00:00[Europe/Stockholm]'
+        ),
+        end: Temporal.ZonedDateTime.from(
+          '2027-01-27T10:00:00[Europe/Stockholm]'
+        ),
+      },
+      {
+        id: 2,
+        title: 'B',
+        start: Temporal.ZonedDateTime.from(
+          '2027-01-27T09:00:00[Europe/Stockholm]'
+        ),
+        end: Temporal.ZonedDateTime.from(
+          '2027-01-27T10:00:00[Europe/Stockholm]'
+        ),
+      },
+      {
+        id: 3,
+        title: 'C',
+        start: Temporal.ZonedDateTime.from(
+          '2027-01-27T09:00:00[Europe/Stockholm]'
+        ),
+        end: Temporal.ZonedDateTime.from(
+          '2027-01-27T10:00:00[Europe/Stockholm]'
+        ),
+      },
+    ]
+
+    it('keeps the default order when monthAgendaOptions.sortEvents is not set', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: Temporal.PlainDate.from('2027-01-27'),
+        events: sameDayEvents,
+      })
+      renderComponent($app)
+
+      expect(getAgendaTitles()).toEqual(['A', 'B', 'C'])
+    })
+
+    it('uses monthAgendaOptions.sortEvents to order the selected day events', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: Temporal.PlainDate.from('2027-01-27'),
+        events: sameDayEvents,
+        monthAgendaOptions: {
+          nEventIndicatorsPerDay: 3,
+          sortEvents: (a, b) => String(b.title).localeCompare(String(a.title)),
+        },
+      })
+      renderComponent($app)
+
+      expect(getAgendaTitles()).toEqual(['C', 'B', 'A'])
+    })
+  })
 })

--- a/packages/calendar/src/views/month-agenda/components/month-agenda-wrapper.tsx
+++ b/packages/calendar/src/views/month-agenda/components/month-agenda-wrapper.tsx
@@ -10,7 +10,11 @@ import { useAgenda } from '../hooks/use-agenda'
 import { isSameDay } from '@schedule-x/shared/src/utils/stateless/time/comparison'
 
 export const MonthAgendaWrapper: PreactViewComponent = ({ $app, id }) => {
-  const agenda = useAgenda($app, createAgendaMonth)
+  const agenda = useAgenda(
+    $app,
+    createAgendaMonth,
+    $app.config.monthAgendaOptions.value.sortEvents
+  )
   const selectedMonth = $app.datePickerState.selectedDate.value.month
 
   useEffect(() => {

--- a/packages/calendar/src/views/month-agenda/hooks/use-agenda.ts
+++ b/packages/calendar/src/views/month-agenda/hooks/use-agenda.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { Agenda } from '../types/month-agenda'
 import { positionEventsInAgenda } from '../utils/stateless/position-events-in-agenda'
 import { sortEventsByStartAndEnd } from '../../../utils/stateless/events/sort-by-start-date'
+import { CalendarEventInternal } from '@schedule-x/shared/src/interfaces/calendar/calendar-event.interface'
 import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
 import TimeUnits from '@schedule-x/shared/src/utils/stateful/time-units/time-units.interface'
 
@@ -12,7 +13,11 @@ type CreateGridFn = (
 
 export function useAgenda(
   $app: CalendarAppSingleton,
-  createGrid: CreateGridFn
+  createGrid: CreateGridFn,
+  sortEvents: (
+    a: CalendarEventInternal,
+    b: CalendarEventInternal
+  ) => number = sortEventsByStartAndEnd
 ): Agenda {
   const getAgenda = () => {
     const filteredEvents = $app.calendarEvents.filterPredicate.value
@@ -28,7 +33,7 @@ export function useAgenda(
         ),
         $app.timeUnitsImpl
       ),
-      filteredEvents.sort(sortEventsByStartAndEnd)
+      filteredEvents.sort(sortEvents)
     )
   }
 

--- a/packages/calendar/src/views/month-grid/components/__test__/month-wrapper.spec.tsx
+++ b/packages/calendar/src/views/month-grid/components/__test__/month-wrapper.spec.tsx
@@ -8,6 +8,7 @@ import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/cal
 import { cleanup, render, waitFor } from '@testing-library/preact'
 import { MonthGridWrapper } from '../month-grid-wrapper'
 import { __createAppWithViews__ } from '../../../../utils/stateless/testing/__create-app-with-views__'
+import { sortEventsForMonthGrid } from '../../../../utils/stateless/events/sort-by-start-date'
 import { afterEach } from 'vitest'
 import 'temporal-polyfill/global'
 
@@ -242,6 +243,56 @@ describe('MonthWrapper', () => {
       expect(weekNumbers[3].textContent).toBe('12')
       expect(weekNumbers[4].textContent).toBe('13')
       expect(weekNumbers[5].textContent).toBe('14')
+    })
+  })
+
+  describe('custom event sorting', () => {
+    // all events start on 2023-10-10; a later end makes a multi-day event
+    const makeEvent = (id: string, title: string, end: string) => ({
+      id,
+      title,
+      start: Temporal.PlainDate.from('2023-10-10'),
+      end: Temporal.PlainDate.from(end),
+    })
+    const events = [
+      makeEvent('c', 'C', '2023-10-10'),
+      makeEvent('b', 'B', '2023-10-12'),
+      makeEvent('a', 'A', '2023-10-10'),
+    ]
+
+    const titles = () => {
+      const cell = document.querySelector('[data-date="2023-10-10"]')
+      return Array.from(
+        cell?.querySelectorAll('.sx__month-grid-event-title') ?? []
+      ).map((el) => el.textContent)
+    }
+
+    it('keeps the default order when monthGridOptions.sortEvents is not set', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: Temporal.PlainDate.from('2023-10-01'),
+        events,
+      })
+      renderComponent($app)
+
+      // default sorting floats the multi-day event (B) to the top
+      expect(titles()).toEqual(['B', 'C', 'A'])
+    })
+
+    it('uses monthGridOptions.sortEvents to order events within a day cell', () => {
+      const $app = __createAppWithViews__({
+        selectedDate: Temporal.PlainDate.from('2023-10-01'),
+        events,
+        monthGridOptions: {
+          nEventsPerDay: 4,
+          sortEvents: (a, b) =>
+            String(a.title).localeCompare(String(b.title)) ||
+            sortEventsForMonthGrid(a, b),
+        },
+      })
+      renderComponent($app)
+
+      // custom comparator overrides the default multi-day float
+      expect(titles()).toEqual(['A', 'B', 'C'])
     })
   })
 })

--- a/packages/calendar/src/views/month-grid/components/month-grid-wrapper.tsx
+++ b/packages/calendar/src/views/month-grid/components/month-grid-wrapper.tsx
@@ -57,9 +57,9 @@ export const MonthGridWrapper: PreactViewComponent = ({ $app, id }) => {
           $app.calendarEvents.filterPredicate.value
         )
       : $app.calendarEvents.list.value
-    setMonth(
-      positionInMonth(newMonth, filteredEvents.sort(sortEventsForMonthGrid))
-    )
+    const sortEvents =
+      $app.config.monthGridOptions.value.sortEvents ?? sortEventsForMonthGrid
+    setMonth(positionInMonth(newMonth, filteredEvents.sort(sortEvents)))
   })
 
   return (

--- a/packages/calendar/src/views/week-agenda/components/__test__/week-agenda-wrapper.spec.tsx
+++ b/packages/calendar/src/views/week-agenda/components/__test__/week-agenda-wrapper.spec.tsx
@@ -1,0 +1,77 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+} from '@schedule-x/shared/src/utils/stateless/testing/unit/unit-testing-library.impl'
+import { cleanup, render } from '@testing-library/preact'
+import CalendarAppSingleton from '@schedule-x/shared/src/interfaces/calendar/calendar-app-singleton'
+import { WeekAgendaWrapper } from '../week-agenda-wrapper'
+import { __createAppWithViews__ } from '../../../../utils/stateless/testing/__create-app-with-views__'
+import 'temporal-polyfill/global'
+
+const renderComponent = ($app: CalendarAppSingleton) => {
+  render(<WeekAgendaWrapper $app={$app} id={'1'} />)
+}
+
+const getEventTitles = () =>
+  Array.from(document.querySelectorAll('.sx__month-agenda-event__title')).map(
+    (el) => el.textContent
+  )
+
+describe('WeekAgendaWrapper', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  /**
+   * useAgenda is shared between the month-agenda and week-agenda views, so a
+   * monthAgendaOptions.sortEvents comparator must NOT leak into the week-agenda.
+   */
+  it('ignores monthAgendaOptions.sortEvents (no leak through the shared useAgenda hook)', () => {
+    const sameDayEvents = [
+      {
+        id: 1,
+        title: 'A',
+        start: Temporal.ZonedDateTime.from(
+          '2027-01-27T09:00:00[Europe/Stockholm]'
+        ),
+        end: Temporal.ZonedDateTime.from(
+          '2027-01-27T10:00:00[Europe/Stockholm]'
+        ),
+      },
+      {
+        id: 2,
+        title: 'B',
+        start: Temporal.ZonedDateTime.from(
+          '2027-01-27T09:00:00[Europe/Stockholm]'
+        ),
+        end: Temporal.ZonedDateTime.from(
+          '2027-01-27T10:00:00[Europe/Stockholm]'
+        ),
+      },
+      {
+        id: 3,
+        title: 'C',
+        start: Temporal.ZonedDateTime.from(
+          '2027-01-27T09:00:00[Europe/Stockholm]'
+        ),
+        end: Temporal.ZonedDateTime.from(
+          '2027-01-27T10:00:00[Europe/Stockholm]'
+        ),
+      },
+    ]
+    const $app = __createAppWithViews__({
+      selectedDate: Temporal.PlainDate.from('2027-01-27'),
+      events: sameDayEvents,
+      monthAgendaOptions: {
+        nEventIndicatorsPerDay: 3,
+        sortEvents: (a, b) => String(b.title).localeCompare(String(a.title)),
+      },
+    })
+    renderComponent($app)
+
+    // The week-agenda keeps the default order despite monthAgendaOptions.sortEvents
+    expect(getEventTitles()).toEqual(['A', 'B', 'C'])
+  })
+})

--- a/packages/shared/src/interfaces/calendar/calendar-config.ts
+++ b/packages/shared/src/interfaces/calendar/calendar-config.ts
@@ -2,7 +2,9 @@ import Config from '../config.interface'
 import { DatePickerConfigExternal } from '../date-picker/config.interface'
 import { ViewName } from '../../types/calendar/view-name'
 import { View } from '../../types/calendar/view'
-import CalendarEventExternal from './calendar-event.interface'
+import CalendarEventExternal, {
+  CalendarEventInternal,
+} from './calendar-event.interface'
 import {
   DayBoundariesExternal,
   DayBoundariesInternal,
@@ -33,10 +35,20 @@ export type WeekOptions = {
 
 export type MonthGridOptions = {
   nEventsPerDay: number
+  /**
+   * Custom comparator for events within a month-grid day cell.
+   * When set, it replaces the default month-grid sorting entirely.
+   */
+  sortEvents?: (a: CalendarEventInternal, b: CalendarEventInternal) => number
 }
 
 export type MonthAgendaOptions = {
   nEventIndicatorsPerDay: number
+  /**
+   * Custom comparator for the events listed for the selected day in the
+   * month-agenda view. When set, it replaces the default sorting entirely.
+   */
+  sortEvents?: (a: CalendarEventInternal, b: CalendarEventInternal) => number
 }
 
 export type ColorDefinition = {

--- a/website/app/docs/calendar/configuration/page.mdx
+++ b/website/app/docs/calendar/configuration/page.mdx
@@ -120,29 +120,6 @@ const config = {
      * Number of events to display in a day cell before the "+ N events" button is shown
      * */
     nEventsPerDay: 8,
-
-    /**
-     * Optional custom comparator for ordering events within a month-grid day cell.
-     * When set, it fully replaces the default month-grid sorting.
-     * The library's default comparators (sortEventsForMonthGrid, sortEventsByStartAndEnd)
-     * are exported from "@schedule-x/calendar", so you can reuse them as a fallback.
-     * */
-    sortEvents: (a, b) =>
-      Number(b.calendarId === 'work') - Number(a.calendarId === 'work') ||
-      sortEventsForMonthGrid(a, b),
-  },
-
-  monthAgendaOptions: {
-    /**
-     * Number of event indicators (dots) to display per day in the month-agenda grid
-     * */
-    nEventIndicatorsPerDay: 3,
-
-    /**
-     * Optional custom comparator for ordering the events listed for the selected day
-     * in the month-agenda view. When set, it fully replaces the default sorting.
-     * */
-    sortEvents: (a, b) => sortEventsByStartAndEnd(a, b),
   },
 
   /**

--- a/website/app/docs/calendar/configuration/page.mdx
+++ b/website/app/docs/calendar/configuration/page.mdx
@@ -120,6 +120,29 @@ const config = {
      * Number of events to display in a day cell before the "+ N events" button is shown
      * */
     nEventsPerDay: 8,
+
+    /**
+     * Optional custom comparator for ordering events within a month-grid day cell.
+     * When set, it fully replaces the default month-grid sorting.
+     * The library's default comparators (sortEventsForMonthGrid, sortEventsByStartAndEnd)
+     * are exported from "@schedule-x/calendar", so you can reuse them as a fallback.
+     * */
+    sortEvents: (a, b) =>
+      Number(b.calendarId === 'work') - Number(a.calendarId === 'work') ||
+      sortEventsForMonthGrid(a, b),
+  },
+
+  monthAgendaOptions: {
+    /**
+     * Number of event indicators (dots) to display per day in the month-agenda grid
+     * */
+    nEventIndicatorsPerDay: 3,
+
+    /**
+     * Optional custom comparator for ordering the events listed for the selected day
+     * in the month-agenda view. When set, it fully replaces the default sorting.
+     * */
+    sortEvents: (a, b) => sortEventsByStartAndEnd(a, b),
   },
 
   /**


### PR DESCRIPTION
Implements the "pass a sort function" approach from #1093 (supersedes my earlier [`sortIndex` draft](https://github.com/Nicolast-Diab/schedule-x/pull/1)).

Adds two **opt-in** comparators to the calendar config:

- `monthGridOptions.sortEvents` — orders events within a month-grid day cell.
- `monthAgendaOptions.sortEvents` — orders the selected day's events in the month-agenda view.

Unset → default sorting is unchanged (no behavior change). Set → fully replaces the default for that view.

**Notes**
- The month-agenda comparator is passed as a parameter into the shared `useAgenda` hook, so it does **not** leak into the week-agenda (which keeps the default).
- `sortEventsForMonthGrid` and `sortEventsByStartAndEnd` are now exported so they can be composed as a fallback:
  ```ts
  sortEvents: (a, b) =>
    Number(b.calendarId === 'work') - Number(a.calendarId === 'work') ||
    sortEventsForMonthGrid(a, b)
  ```
- Comparators are typed `CalendarEventInternal` (matching the existing ones); glad to switch to `CalendarEventExternal` if you prefer a lighter public type.

**Tests:** unit specs for both options plus a guard that the week-agenda is unaffected; full `@schedule-x/calendar` suite green.

## Checklist
- [x] Tested in different browsers
- [x] Issue submitted first (#1093)
- [x] Tests added for the new feature
- [x] No breaking changes (opt-in; default behavior unchanged)

Example where multi-day gets below "work" items
<img width="417" height="273" alt="image" src="https://github.com/user-attachments/assets/9abf64d2-b3c6-44f5-bed2-78d0b38cd0fb" />

